### PR TITLE
Make Rope::byte_to_line public

### DIFF
--- a/src/rope.rs
+++ b/src/rope.rs
@@ -620,7 +620,7 @@ impl Rope {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[allow(dead_code)]
-    pub(crate) fn byte_to_line(&self, byte_idx: usize) -> usize {
+    pub fn byte_to_line(&self, byte_idx: usize) -> usize {
         // Bounds check
         assert!(
             byte_idx <= self.len_bytes(),


### PR DESCRIPTION
I have an internal abstraction which maintains span information as byte offsets into valid utf-8.

In order to translate these into lines/cols it seems like I need this function to be public.