### PR TITLE
UTF-16 code unit index conversion support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### New features
+- `Rope` and `RopeSlice` can now convert between char indices and utf16 code unit indices.  This useful when interacting with external APIs that use utf16 code units as their text indexing scheme.
+
+### Dependencies
+- Updated smallvec to minimum version 1.0.
+
 
 ## [1.1.0] - 2019-09-01
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -807,6 +807,7 @@ impl<'a> Chunks<'a> {
                             info = TextInfo {
                                 bytes: byte_idx_range.1 as u64,
                                 chars: char_idx_range.1 as u64,
+                                utf16_surrogates: 0, // Bogus value, not needed
                                 line_breaks: line_break_idx_range.1 as u64 - 1,
                             };
                             (*node_stack.last_mut().unwrap()).1 += 1;

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -888,9 +888,8 @@ impl Rope {
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
-    /// Note: since utf16 code units can be in the middle of a char, this
-    /// returns the char index of a the char that the utf16 code unit is a
-    /// part of.
+    /// Note: if the utf16 code unit is in the middle of a char, returns the
+    /// index of the char that it belongs to.
     ///
     /// Runs in O(log N) time.
     ///

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -958,7 +958,7 @@ impl Rope {
     #[inline]
     pub fn line(&self, line_idx: usize) -> RopeSlice {
         use slice::RSEnum;
-        use str_utils::count_chars;
+        use str_utils::{count_chars, count_utf16_surrogates};
 
         let len_lines = self.len_lines();
 
@@ -978,6 +978,7 @@ impl Rope {
             RopeSlice(RSEnum::Light {
                 text: text2,
                 char_count: count_chars(text2) as Count,
+                utf16_surrogate_count: count_utf16_surrogates(text2) as Count,
                 line_break_count: if line_idx == (len_lines - 1) { 0 } else { 1 },
             })
         } else {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -365,9 +365,8 @@ impl<'a> RopeSlice<'a> {
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
-    /// Note: since utf16 code units can be in the middle of a char, this
-    /// returns the char index of a the char that the utf16 code unit is a
-    /// part of.
+    /// Note: if the utf16 code unit is in the middle of a char, returns the
+    /// index of the char that it belongs to.
     ///
     /// Runs in O(log N) time.
     ///

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -264,6 +264,11 @@ fn count_utf16_surrogates_internal<T: ByteChunk>(text: &[u8]) -> usize {
     utf16_surrogate_count
 }
 
+#[inline(always)]
+pub(crate) fn byte_to_utf16_surrogate_idx(text: &str, byte_idx: usize) -> usize {
+    count_utf16_surrogates(&text[..byte_idx])
+}
+
 //===========================================================================
 // Internal
 //===========================================================================

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -269,6 +269,28 @@ pub(crate) fn byte_to_utf16_surrogate_idx(text: &str, byte_idx: usize) -> usize 
     count_utf16_surrogates(&text[..byte_idx])
 }
 
+#[inline(always)]
+pub(crate) fn utf16_code_unit_to_char_idx(text: &str, utf16_idx: usize) -> usize {
+    // TODO: optimized version.  This is pretty slow.  It isn't expected to be
+    // used in performance critical functionality, so this isn't urgent.  But
+    // might as well make it faster when we get the chance.
+    let mut char_i = 0;
+    let mut utf16_i = 0;
+    for c in text.chars() {
+        if utf16_idx <= utf16_i {
+            break;
+        }
+        char_i += 1;
+        utf16_i += c.len_utf16();
+    }
+
+    if utf16_idx < utf16_i {
+        char_i -= 1;
+    }
+
+    char_i
+}
+
 //===========================================================================
 // Internal
 //===========================================================================

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -495,6 +495,28 @@ impl Node {
         }
     }
 
+    /// Returns the chunk that contains the given utf16 code unit, and the
+    /// TextInfo corresponding to the start of the chunk.
+    pub fn get_chunk_at_utf16_code_unit(&self, utf16_idx: usize) -> (&str, TextInfo) {
+        let mut node = self;
+        let mut utf16_idx = utf16_idx;
+        let mut info = TextInfo::new();
+
+        loop {
+            match *node {
+                Node::Leaf(ref text) => {
+                    return (text, info);
+                }
+                Node::Internal(ref children) => {
+                    let (child_i, acc_info) = children.search_utf16_code_unit_idx(utf16_idx);
+                    info += acc_info;
+                    node = &*children.nodes()[child_i];
+                    utf16_idx -= (acc_info.chars + acc_info.utf16_surrogates) as usize;
+                }
+            }
+        }
+    }
+
     /// Returns the chunk that contains the given line break, and the TextInfo
     /// corresponding to the start of the chunk.
     ///

--- a/src/tree/text_info.rs
+++ b/src/tree/text_info.rs
@@ -1,12 +1,13 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use str_utils::{count_chars, count_line_breaks};
+use str_utils::{count_chars, count_line_breaks, count_utf16_surrogates};
 use tree::Count;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextInfo {
     pub(crate) bytes: Count,
     pub(crate) chars: Count,
+    pub(crate) utf16_surrogates: Count,
     pub(crate) line_breaks: Count,
 }
 
@@ -16,6 +17,7 @@ impl TextInfo {
         TextInfo {
             bytes: 0,
             chars: 0,
+            utf16_surrogates: 0,
             line_breaks: 0,
         }
     }
@@ -25,6 +27,7 @@ impl TextInfo {
         TextInfo {
             bytes: text.len() as Count,
             chars: count_chars(text) as Count,
+            utf16_surrogates: count_utf16_surrogates(text) as Count,
             line_breaks: count_line_breaks(text) as Count,
         }
     }
@@ -37,6 +40,7 @@ impl Add for TextInfo {
         TextInfo {
             bytes: self.bytes + rhs.bytes,
             chars: self.chars + rhs.chars,
+            utf16_surrogates: self.utf16_surrogates + rhs.utf16_surrogates,
             line_breaks: self.line_breaks + rhs.line_breaks,
         }
     }
@@ -56,6 +60,7 @@ impl Sub for TextInfo {
         TextInfo {
             bytes: self.bytes - rhs.bytes,
             chars: self.chars - rhs.chars,
+            utf16_surrogates: self.utf16_surrogates - rhs.utf16_surrogates,
             line_breaks: self.line_breaks - rhs.line_breaks,
         }
     }


### PR DESCRIPTION
Some software and APIs, especially on the Windows platform, still operate in terms of UTF-16 code units when working with text. One example is the Language Server Protocol, which specifies text offsets in UTF-16 code units.  Being able to efficiently interoperate with these APIs is useful, especially for code editors.

To support this use-case, this PR adds the ability to convert between Unicode scalar value indices (which Ropey uses) and UTF-16 code unit indices.