### PR TITLE
Update to 2018 edition, and fix all clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ropey"
 version = "1.2.0"
 authors = ["Nathan Vegdahl <cessen@cessen.com>"]
+edition = "2018"
 description = "A fast and robust text rope for Rust"
 documentation = "https://docs.rs/ropey"
 repository = "https://github.com/cessen/ropey"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "ropey"
 version = "1.2.0"
 authors = ["Nathan Vegdahl <cessen@cessen.com>"]
-edition = "2018"
 description = "A fast and robust text rope for Rust"
 documentation = "https://docs.rs/ropey"
 repository = "https://github.com/cessen/ropey"

--- a/benches/iterators.rs
+++ b/benches/iterators.rs
@@ -129,7 +129,7 @@ fn bytes_iter_prev(bench: &mut Bencher) {
     let itr_src = r.bytes_at(r.len_bytes());
     let mut itr = itr_src.clone();
     bench.iter(|| {
-        if let None = itr.prev() {
+        if itr.prev().is_none() {
             itr = itr_src.clone();
         }
     });
@@ -148,7 +148,7 @@ fn chars_iter_prev(bench: &mut Bencher) {
     let itr_src = r.chars_at(r.len_chars());
     let mut itr = itr_src.clone();
     bench.iter(|| {
-        if let None = itr.prev() {
+        if itr.prev().is_none() {
             itr = itr_src.clone();
         }
     });
@@ -175,7 +175,7 @@ fn lines_iter_prev(bench: &mut Bencher) {
     let itr_src = r.lines_at(r.len_lines());
     let mut itr = itr_src.clone();
     bench.iter(|| {
-        if let None = itr.prev() {
+        if itr.prev().is_none() {
             itr = itr_src.clone();
         }
     });
@@ -186,7 +186,7 @@ fn lines_iter_prev_tiny(bench: &mut Bencher) {
     let itr_src = r.lines_at(r.len_lines());
     let mut itr = itr_src.clone();
     bench.iter(|| {
-        if let None = itr.prev() {
+        if itr.prev().is_none() {
             itr = itr_src.clone();
         }
     });
@@ -205,7 +205,7 @@ fn chunks_iter_prev(bench: &mut Bencher) {
     let itr_src = r.chunks_at_char(r.len_chars()).0;
     let mut itr = itr_src.clone();
     bench.iter(|| {
-        if let None = itr.prev() {
+        if itr.prev().is_none() {
             itr = itr_src.clone();
         }
     });

--- a/examples/graphemes_iter.rs
+++ b/examples/graphemes_iter.rs
@@ -28,7 +28,7 @@ impl<'a> RopeGraphemes<'a> {
         let first_chunk = chunks.next().unwrap_or("");
         RopeGraphemes {
             text: *slice,
-            chunks: chunks,
+            chunks,
             cur_chunk: first_chunk,
             cur_chunk_start: 0,
             cursor: GraphemeCursor::new(0, slice.len_bytes(), true),
@@ -76,7 +76,7 @@ impl<'a> Iterator for RopeGraphemes<'a> {
 }
 
 #[cfg(test)]
-#[cfg_attr(rustfmt, rustfmt_skip)] // Because of the crazy long graphemes
+#[rustfmt::skip] // Because of the crazy long graphemes
 mod tests {
     use super::*;
     use ropey::Rope;

--- a/examples/graphemes_iter.rs
+++ b/examples/graphemes_iter.rs
@@ -28,7 +28,7 @@ impl<'a> RopeGraphemes<'a> {
         let first_chunk = chunks.next().unwrap_or("");
         RopeGraphemes {
             text: *slice,
-            chunks,
+            chunks: chunks,
             cur_chunk: first_chunk,
             cur_chunk_start: 0,
             cursor: GraphemeCursor::new(0, slice.len_bytes(), true),

--- a/examples/graphemes_step.rs
+++ b/examples/graphemes_step.rs
@@ -115,7 +115,7 @@ fn is_grapheme_boundary(slice: &RopeSlice, char_idx: usize) -> bool {
 }
 
 #[cfg(test)]
-#[cfg_attr(rustfmt, rustfmt_skip)] // Because of the crazy long graphemes
+#[rustfmt::skip] // Because of the crazy long graphemes
 mod tests {
     use super::*;
     use ropey::Rope;

--- a/examples/search_and_replace.rs
+++ b/examples/search_and_replace.rs
@@ -89,7 +89,7 @@ fn search_and_replace(rope: &mut Rope, search_pattern: &str, replacement_text: &
         }
 
         // If there are no matches, we're done!
-        if matches.len() == 0 {
+        if matches.is_empty() {
             break;
         }
 
@@ -135,12 +135,12 @@ struct SearchIter<'a> {
 impl<'a> SearchIter<'a> {
     fn from_rope_slice<'b>(slice: &'b RopeSlice, search_pattern: &'b str) -> SearchIter<'b> {
         assert!(
-            search_pattern.len() > 0,
+            !search_pattern.is_empty(),
             "Can't search using an empty search pattern."
         );
         SearchIter {
             char_iter: slice.chars(),
-            search_pattern: search_pattern,
+            search_pattern,
             search_pattern_char_len: search_pattern.chars().count(),
             cur_index: 0,
             possible_matches: Vec::new(),
@@ -188,6 +188,6 @@ impl<'a> Iterator for SearchIter<'a> {
             }
         }
 
-        return None;
+        None
     }
 }

--- a/examples/search_and_replace.rs
+++ b/examples/search_and_replace.rs
@@ -140,7 +140,7 @@ impl<'a> SearchIter<'a> {
         );
         SearchIter {
             char_iter: slice.chars(),
-            search_pattern,
+            search_pattern: search_pattern,
             search_pattern_char_len: search_pattern.chars().count(),
             cur_index: 0,
             possible_matches: Vec::new(),

--- a/examples/simple_buffer.rs
+++ b/examples/simple_buffer.rs
@@ -18,7 +18,7 @@ impl TextBuffer {
     fn from_path(path: &str) -> io::Result<TextBuffer> {
         let text = Rope::from_reader(&mut io::BufReader::new(File::open(&path)?))?;
         Ok(TextBuffer {
-            text: text,
+            text,
             path: path.to_string(),
             dirty: false,
         })
@@ -48,7 +48,7 @@ impl TextBuffer {
         if start != end {
             self.text.remove(start..end);
         }
-        if text.len() > 0 {
+        if !text.is_empty() {
             self.text.insert(start, text);
         }
         self.dirty = true;

--- a/examples/simple_buffer.rs
+++ b/examples/simple_buffer.rs
@@ -18,7 +18,7 @@ impl TextBuffer {
     fn from_path(path: &str) -> io::Result<TextBuffer> {
         let text = Rope::from_reader(&mut io::BufReader::new(File::open(&path)?))?;
         Ok(TextBuffer {
-            text,
+            text: text,
             path: path.to_string(),
             dirty: false,
         })

--- a/src/crlf.rs
+++ b/src/crlf.rs
@@ -127,9 +127,9 @@ mod tests {
 
     #[test]
     fn crlf_segmenter_01() {
-        let text = "Hello world!\r\nHow's it going?".as_bytes();
+        let text = b"Hello world!\r\nHow's it going?";
 
-        assert!(is_break(0, "".as_bytes()));
+        assert!(is_break(0, b""));
         assert!(is_break(0, text));
         assert!(is_break(12, text));
         assert!(!is_break(13, text));
@@ -139,20 +139,20 @@ mod tests {
 
     #[test]
     fn crlf_segmenter_02() {
-        let l = "Hello world!\r".as_bytes();
-        let r = "\nHow's it going?".as_bytes();
+        let l = b"Hello world!\r";
+        let r = b"\nHow's it going?";
 
         assert!(!seam_is_break(l, r));
-        assert!(!seam_is_break(l, "\n".as_bytes()));
-        assert!(!seam_is_break("\r".as_bytes(), r));
-        assert!(!seam_is_break("\r".as_bytes(), "\n".as_bytes()));
+        assert!(!seam_is_break(l, b"\n"));
+        assert!(!seam_is_break(b"\r", r));
+        assert!(!seam_is_break(b"\r", b"\n"));
         assert!(seam_is_break(r, l));
-        assert!(seam_is_break("\n".as_bytes(), "\r".as_bytes()));
+        assert!(seam_is_break(b"\n", b"\r"));
     }
 
     #[test]
     fn nearest_internal_break_01() {
-        let text = "Hello world!".as_bytes();
+        let text = b"Hello world!";
         assert_eq!(1, nearest_internal_break(0, text));
         assert_eq!(6, nearest_internal_break(6, text));
         assert_eq!(11, nearest_internal_break(12, text));
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn nearest_internal_break_02() {
-        let text = "Hello\r\n world!".as_bytes();
+        let text = b"Hello\r\n world!";
         assert_eq!(5, nearest_internal_break(5, text));
         assert_eq!(7, nearest_internal_break(6, text));
         assert_eq!(7, nearest_internal_break(7, text));
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn nearest_internal_break_03() {
-        let text = "\r\nHello world!\r\n".as_bytes();
+        let text = b"\r\nHello world!\r\n";
         assert_eq!(2, nearest_internal_break(0, text));
         assert_eq!(2, nearest_internal_break(1, text));
         assert_eq!(2, nearest_internal_break(2, text));
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn nearest_internal_break_04() {
-        let text = "\r\n".as_bytes();
+        let text = b"\r\n";
         assert_eq!(2, nearest_internal_break(0, text));
         assert_eq!(2, nearest_internal_break(1, text));
         assert_eq!(2, nearest_internal_break(2, text));
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn is_break_01() {
-        let text = "\n\r\n\r\n\r\n\r\n\r\n\r".as_bytes();
+        let text = b"\n\r\n\r\n\r\n\r\n\r\n\r";
 
         assert!(is_break(0, text));
         assert!(is_break(12, text));
@@ -197,16 +197,16 @@ mod tests {
 
     #[test]
     fn seam_is_break_01() {
-        let text1 = "\r\n\r\n\r\n".as_bytes();
-        let text2 = "\r\n\r\n".as_bytes();
+        let text1 = b"\r\n\r\n\r\n";
+        let text2 = b"\r\n\r\n";
 
         assert!(seam_is_break(text1, text2));
     }
 
     #[test]
     fn seam_is_break_02() {
-        let text1 = "\r\n\r\n\r".as_bytes();
-        let text2 = "\n\r\n\r\n".as_bytes();
+        let text1 = b"\r\n\r\n\r";
+        let text2 = b"\n\r\n\r\n";
 
         assert!(!seam_is_break(text1, text2));
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -50,12 +50,12 @@
 use std::str;
 use std::sync::Arc;
 
-use slice::RopeSlice;
-use str_utils::{
+use crate::slice::RopeSlice;
+use crate::str_utils::{
     byte_to_line_idx, char_to_byte_idx, count_chars, ends_with_line_break, line_to_byte_idx,
     line_to_char_idx, prev_line_end_char_idx,
 };
-use tree::{Node, TextInfo};
+use crate::tree::{Node, TextInfo};
 
 //==========================================================
 
@@ -1054,7 +1054,7 @@ impl<'a> Iterator for Chunks<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Rope;
+    use crate::Rope;
 
     const TEXT: &str = "\r\n\
                         Hello there!  How're you doing?  It's a fine day, \

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -542,7 +542,7 @@ impl<'a> Lines<'a> {
                 ..
             }) => {
                 // Special cases.
-                if *at_end && (text.len() == 0 || ends_with_line_break(text)) {
+                if *at_end && (text.is_empty() || ends_with_line_break(text)) {
                     *line_idx -= 1;
                     *at_end = false;
                     return Some("".into());
@@ -1274,7 +1274,7 @@ mod tests {
 
         assert_eq!(byte_count, bytes.len());
 
-        while let Some(_) = bytes.prev() {
+        while bytes.prev().is_some() {
             byte_count += 1;
             assert_eq!(byte_count, bytes.len());
         }
@@ -1434,7 +1434,7 @@ mod tests {
 
         assert_eq!(char_count, chars.len());
 
-        while let Some(_) = chars.prev() {
+        while chars.prev().is_some() {
             char_count += 1;
             assert_eq!(char_count, chars.len());
         }
@@ -1888,7 +1888,7 @@ mod tests {
 
         assert_eq!(line_count, lines.len());
 
-        while let Some(_) = lines.prev() {
+        while lines.prev().is_some() {
             line_count += 1;
             assert_eq!(line_count, lines.len());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,6 @@ mod tree;
 pub mod iter;
 pub mod str_utils;
 
-pub use rope::Rope;
-pub use rope_builder::RopeBuilder;
-pub use slice::RopeSlice;
+pub use crate::rope::Rope;
+pub use crate::rope_builder::RopeBuilder;
+pub use crate::slice::RopeSlice;

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -1,4 +1,4 @@
-use std;
+
 use std::io;
 use std::iter::FromIterator;
 use std::ops::RangeBounds;
@@ -1002,7 +1002,7 @@ impl Rope {
 
         let (chunk, _, chunk_char_idx, _) = self.chunk_at_char(char_idx);
         let byte_idx = char_to_byte_idx(chunk, char_idx - chunk_char_idx);
-        chunk[byte_idx..].chars().nth(0).unwrap()
+        chunk[byte_idx..].chars().next().unwrap()
     }
 
     /// Returns the line at `line_idx`.

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -5,15 +5,15 @@ use std::ops::RangeBounds;
 use std::ptr;
 use std::sync::Arc;
 
-use crlf;
-use iter::{Bytes, Chars, Chunks, Lines};
-use rope_builder::RopeBuilder;
-use slice::{end_bound_to_num, start_bound_to_num, RopeSlice};
-use str_utils::{
+use crate::crlf;
+use crate::iter::{Bytes, Chars, Chunks, Lines};
+use crate::rope_builder::RopeBuilder;
+use crate::slice::{end_bound_to_num, start_bound_to_num, RopeSlice};
+use crate::str_utils::{
     byte_to_char_idx, byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx,
     char_to_line_idx, line_to_byte_idx, line_to_char_idx, utf16_code_unit_to_char_idx,
 };
-use tree::{Count, Node, NodeChildren, TextInfo, MAX_BYTES};
+use crate::tree::{Count, Node, NodeChildren, TextInfo, MAX_BYTES};
 
 /// A utf8 text rope.
 ///
@@ -1016,8 +1016,8 @@ impl Rope {
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx >= len_lines()`).
     #[inline]
     pub fn line(&self, line_idx: usize) -> RopeSlice {
-        use slice::RSEnum;
-        use str_utils::{count_chars, count_utf16_surrogates};
+        use crate::slice::RSEnum;
+        use crate::str_utils::{count_chars, count_utf16_surrogates};
 
         let len_lines = self.len_lines();
 
@@ -1527,7 +1527,7 @@ impl From<String> for Rope {
 /// Runs in O(log N) time.
 impl<'a> From<RopeSlice<'a>> for Rope {
     fn from(s: RopeSlice<'a>) -> Self {
-        use slice::RSEnum;
+        use crate::slice::RSEnum;
         match s {
             RopeSlice(RSEnum::Full {
                 node,
@@ -1753,7 +1753,7 @@ impl std::cmp::PartialOrd<Rope> for Rope {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use str_utils::byte_to_char_idx;
+    use crate::str_utils::byte_to_char_idx;
 
     // 127 bytes, 103 chars, 1 line
     const TEXT: &str = "Hello there!  How're you doing?  It's \

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -1,4 +1,3 @@
-
 use std::io;
 use std::iter::FromIterator;
 use std::ops::RangeBounds;

--- a/src/rope_builder.rs
+++ b/src/rope_builder.rs
@@ -1,4 +1,4 @@
-use std;
+
 use std::sync::Arc;
 
 use smallvec::SmallVec;

--- a/src/rope_builder.rs
+++ b/src/rope_builder.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 
 use smallvec::SmallVec;
 
-use crlf;
-use rope::Rope;
-use tree::{Node, NodeChildren, NodeText, MAX_BYTES, MAX_CHILDREN};
+use crate::crlf;
+use crate::rope::Rope;
+use crate::tree::{Node, NodeChildren, NodeText, MAX_BYTES, MAX_CHILDREN};
 
 /// An efficient incremental `Rope` builder.
 ///

--- a/src/rope_builder.rs
+++ b/src/rope_builder.rs
@@ -1,4 +1,3 @@
-
 use std::sync::Arc;
 
 use smallvec::SmallVec;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,4 +1,4 @@
-use std;
+
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
@@ -514,7 +514,7 @@ impl<'a> RopeSlice<'a> {
 
         let (chunk, _, chunk_char_idx, _) = self.chunk_at_char(char_idx);
         let byte_idx = char_to_byte_idx(chunk, char_idx - chunk_char_idx);
-        chunk[byte_idx..].chars().nth(0).unwrap()
+        chunk[byte_idx..].chars().next().unwrap()
     }
 
     /// Returns the line at `line_idx`.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,14 +2,14 @@ use std;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
-use iter::{Bytes, Chars, Chunks, Lines};
-use rope::Rope;
-use str_utils::{
+use crate::iter::{Bytes, Chars, Chunks, Lines};
+use crate::rope::Rope;
+use crate::str_utils::{
     byte_to_char_idx, byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx,
     char_to_line_idx, count_chars, count_line_breaks, count_utf16_surrogates, line_to_byte_idx,
     line_to_char_idx, utf16_code_unit_to_char_idx,
 };
-use tree::{Count, Node, TextInfo};
+use crate::tree::{Count, Node, TextInfo};
 
 /// An immutable view into part of a `Rope`.
 ///
@@ -1575,8 +1575,10 @@ impl<'a, 'b> std::cmp::PartialOrd<RopeSlice<'b>> for RopeSlice<'a> {
 
 #[cfg(test)]
 mod tests {
-    use str_utils::{byte_to_char_idx, byte_to_line_idx, char_to_byte_idx, char_to_line_idx};
-    use Rope;
+    use crate::str_utils::{
+        byte_to_char_idx, byte_to_line_idx, char_to_byte_idx, char_to_line_idx,
+    };
+    use crate::Rope;
 
     // 127 bytes, 103 chars, 1 line
     const TEXT: &str = "Hello there!  How're you doing?  It's \

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1519,19 +1519,19 @@ impl<'a> std::cmp::Ord for RopeSlice<'a> {
 
         loop {
             if chunk1.len() >= chunk2.len() {
-                if &chunk1[..chunk2.len()] < chunk2 {
-                    return std::cmp::Ordering::Less;
-                } else if &chunk1[..chunk2.len()] > chunk2 {
-                    return std::cmp::Ordering::Greater;
+                let compared = chunk1[..chunk2.len()].cmp(chunk2);
+                if compared != std::cmp::Ordering::Equal {
+                    return compared;
                 }
+
                 chunk1 = &chunk1[chunk2.len()..];
                 chunk2 = &[];
             } else {
-                if chunk1 < &chunk2[..chunk1.len()] {
-                    return std::cmp::Ordering::Less;
-                } else if chunk1 > &chunk2[..chunk1.len()] {
-                    return std::cmp::Ordering::Greater;
+                let compared = chunk1.cmp(&chunk2[..chunk1.len()]);
+                if compared != std::cmp::Ordering::Equal {
+                    return compared;
                 }
+
                 chunk1 = &[];
                 chunk2 = &chunk2[chunk1.len()..];
             }
@@ -1553,13 +1553,7 @@ impl<'a> std::cmp::Ord for RopeSlice<'a> {
             }
         }
 
-        if self.len_bytes() > other.len_bytes() {
-            return std::cmp::Ordering::Greater;
-        } else if self.len_bytes() < other.len_bytes() {
-            return std::cmp::Ordering::Less;
-        } else {
-            return std::cmp::Ordering::Equal;
-        }
+        self.len_bytes().cmp(&other.len_bytes())
     }
 }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,4 +1,3 @@
-
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -36,7 +36,7 @@ pub fn byte_to_char_idx(text: &str, byte_idx: usize) -> usize {
 /// Any past-the-end index will return the last line index.
 #[inline]
 pub fn byte_to_line_idx(text: &str, byte_idx: usize) -> usize {
-    use crlf;
+    use crate::crlf;
     let mut byte_idx = byte_idx.min(text.len());
     while !text.is_char_boundary(byte_idx) {
         byte_idx -= 1;

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -4,7 +4,7 @@
 //! slices in ways compatible with Ropey.  They may be useful when building
 //! additional functionality on top of Ropey.
 
-use std;
+
 
 // Get the appropriate module (if any) for sse2 types and intrinsics for the
 // platform we're compiling for.

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -4,8 +4,6 @@
 //! slices in ways compatible with Ropey.  They may be useful when building
 //! additional functionality on top of Ropey.
 
-
-
 // Get the appropriate module (if any) for sse2 types and intrinsics for the
 // platform we're compiling for.
 #[cfg(target_arch = "x86")]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,4 +1,4 @@
-use std;
+
 use std::sync::Arc;
 
 use crate::str_utils::{byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx};

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,9 +1,9 @@
 use std;
 use std::sync::Arc;
 
-use str_utils::{byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx};
-use tree::node_text::fix_segment_seam;
-use tree::{
+use crate::str_utils::{byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx};
+use crate::tree::node_text::fix_segment_seam;
+use crate::tree::{
     Count, NodeChildren, NodeText, TextInfo, MAX_BYTES, MAX_CHILDREN, MIN_BYTES, MIN_CHILDREN,
 };
 
@@ -964,7 +964,7 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
-    use Rope;
+    use crate::Rope;
 
     // 133 chars, 209 bytes
     const TEXT: &str = "\r\nHello there!  How're you doing?  It's a fine day, \
@@ -997,9 +997,9 @@ mod tests {
     #[test]
     fn crlf_corner_case_01() {
         use super::Node;
+        use crate::tree::{NodeChildren, NodeText, MAX_BYTES};
         use std::iter;
         use std::sync::Arc;
-        use tree::{NodeChildren, NodeText, MAX_BYTES};
 
         // Construct the corner case
         let nodel = Node::Leaf(NodeText::from_str(
@@ -1025,9 +1025,9 @@ mod tests {
     #[test]
     fn crlf_corner_case_02() {
         use super::Node;
+        use crate::tree::{NodeChildren, NodeText, MAX_BYTES};
         use std::iter;
         use std::sync::Arc;
-        use tree::{NodeChildren, NodeText, MAX_BYTES};
 
         // Construct the corner case
         let nodel = Node::Leaf(NodeText::from_str(

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,4 +1,3 @@
-
 use std::sync::Arc;
 
 use crate::str_utils::{byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx};

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -3,8 +3,8 @@ use std::iter::{Iterator, Zip};
 use std::slice;
 use std::sync::Arc;
 
-use crlf;
-use tree::{self, Node, TextInfo, MAX_BYTES};
+use crate::crlf;
+use crate::tree::{self, Node, TextInfo, MAX_BYTES};
 
 const MAX_LEN: usize = tree::MAX_CHILDREN;
 
@@ -749,8 +749,8 @@ mod inner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tree::{Node, NodeText, TextInfo};
     use std::sync::Arc;
-    use tree::{Node, NodeText, TextInfo};
 
     #[test]
     fn search_char_idx_01() {

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -570,7 +570,7 @@ mod inner {
 
         /// Access to the info array.
         #[inline(always)]
-        pub fn info(& self) -> & [TextInfo] {
+        pub fn info(&self) -> &[TextInfo] {
             unsafe { &*(&self.info[..(self.len())] as *const _ as *const _) }
         }
 

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -526,7 +526,6 @@ impl fmt::Debug for NodeChildren {
 /// and it was a pain to track down--as memory safety bugs often are.
 mod inner {
     use super::{Node, TextInfo, MAX_LEN};
-    use std::mem;
     use std::mem::MaybeUninit;
     use std::ptr;
     use std::sync::Arc;
@@ -560,33 +559,33 @@ mod inner {
         /// Access to the nodes array.
         #[inline(always)]
         pub fn nodes<'a>(&'a self) -> &'a [Arc<Node>] {
-            unsafe { mem::transmute(&self.nodes[..(self.len())]) }
+            unsafe { &*(&self.nodes[..(self.len())] as *const _ as *const _) }
         }
 
         /// Mutable access to the nodes array.
         #[inline(always)]
         pub fn nodes_mut<'a>(&'a mut self) -> &'a mut [Arc<Node>] {
-            unsafe { mem::transmute(&mut self.nodes[..(self.len as usize)]) }
+            unsafe { &mut *(&mut self.nodes[..(self.len as usize)] as *mut _ as *mut _) }
         }
 
         /// Access to the info array.
         #[inline(always)]
         pub fn info<'a>(&'a self) -> &'a [TextInfo] {
-            unsafe { mem::transmute(&self.info[..(self.len())]) }
+            unsafe { &*(&self.info[..(self.len())] as *const _ as *const _) }
         }
 
         /// Mutable access to the info array.
         #[inline(always)]
         pub fn info_mut<'a>(&'a mut self) -> &'a mut [TextInfo] {
-            unsafe { mem::transmute(&mut self.info[..(self.len as usize)]) }
+            unsafe { &mut *(&mut self.info[..(self.len as usize)] as *mut _ as *mut _) }
         }
 
         /// Mutable access to both the info and nodes arrays simultaneously.
         #[inline(always)]
         pub fn data_mut<'a>(&'a mut self) -> (&'a mut [TextInfo], &'a mut [Arc<Node>]) {
             (
-                unsafe { mem::transmute(&mut self.info[..(self.len as usize)]) },
-                unsafe { mem::transmute(&mut self.nodes[..(self.len as usize)]) },
+                unsafe { &mut *(&mut self.info[..(self.len as usize)] as *mut _ as *mut _) },
+                unsafe { &mut *(&mut self.nodes[..(self.len as usize)] as *mut _ as *mut _) },
             )
         }
 

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -564,19 +564,19 @@ mod inner {
 
         /// Mutable access to the nodes array.
         #[inline(always)]
-        pub fn nodes_mut<'a>(&'a mut self) -> &'a mut [Arc<Node>] {
+        pub fn nodes_mut(&mut self) -> &mut [Arc<Node>] {
             unsafe { &mut *(&mut self.nodes[..(self.len as usize)] as *mut _ as *mut _) }
         }
 
         /// Access to the info array.
         #[inline(always)]
-        pub fn info<'a>(&'a self) -> &'a [TextInfo] {
+        pub fn info(& self) -> & [TextInfo] {
             unsafe { &*(&self.info[..(self.len())] as *const _ as *const _) }
         }
 
         /// Mutable access to the info array.
         #[inline(always)]
-        pub fn info_mut<'a>(&'a mut self) -> &'a mut [TextInfo] {
+        pub fn info_mut(&mut self) -> &mut [TextInfo] {
             unsafe { &mut *(&mut self.info[..(self.len as usize)] as *mut _ as *mut _) }
         }
 

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -526,6 +526,7 @@ impl fmt::Debug for NodeChildren {
 /// and it was a pain to track down--as memory safety bugs often are.
 mod inner {
     use super::{Node, TextInfo, MAX_LEN};
+    use std::mem;
     use std::mem::MaybeUninit;
     use std::ptr;
     use std::sync::Arc;
@@ -559,33 +560,33 @@ mod inner {
         /// Access to the nodes array.
         #[inline(always)]
         pub fn nodes<'a>(&'a self) -> &'a [Arc<Node>] {
-            unsafe { &*(&self.nodes[..(self.len())] as *const _ as *const _) }
+            unsafe { mem::transmute(&self.nodes[..(self.len())]) }
         }
 
         /// Mutable access to the nodes array.
         #[inline(always)]
-        pub fn nodes_mut(&mut self) -> &mut [Arc<Node>] {
-            unsafe { &mut *(&mut self.nodes[..(self.len as usize)] as *mut _ as *mut _) }
+        pub fn nodes_mut<'a>(&'a mut self) -> &'a mut [Arc<Node>] {
+            unsafe { mem::transmute(&mut self.nodes[..(self.len as usize)]) }
         }
 
         /// Access to the info array.
         #[inline(always)]
-        pub fn info(&self) -> &[TextInfo] {
-            unsafe { &*(&self.info[..(self.len())] as *const _ as *const _) }
+        pub fn info<'a>(&'a self) -> &'a [TextInfo] {
+            unsafe { mem::transmute(&self.info[..(self.len())]) }
         }
 
         /// Mutable access to the info array.
         #[inline(always)]
-        pub fn info_mut(&mut self) -> &mut [TextInfo] {
-            unsafe { &mut *(&mut self.info[..(self.len as usize)] as *mut _ as *mut _) }
+        pub fn info_mut<'a>(&'a mut self) -> &'a mut [TextInfo] {
+            unsafe { mem::transmute(&mut self.info[..(self.len as usize)]) }
         }
 
         /// Mutable access to both the info and nodes arrays simultaneously.
         #[inline(always)]
         pub fn data_mut<'a>(&'a mut self) -> (&'a mut [TextInfo], &'a mut [Arc<Node>]) {
             (
-                unsafe { &mut *(&mut self.info[..(self.len as usize)] as *mut _ as *mut _) },
-                unsafe { &mut *(&mut self.nodes[..(self.len as usize)] as *mut _ as *mut _) },
+                unsafe { mem::transmute(&mut self.info[..(self.len as usize)]) },
+                unsafe { mem::transmute(&mut self.nodes[..(self.len as usize)]) },
             )
         }
 

--- a/src/tree/node_text.rs
+++ b/src/tree/node_text.rs
@@ -1,4 +1,4 @@
-use std;
+
 
 use std::borrow::Borrow;
 use std::ops::Deref;

--- a/src/tree/node_text.rs
+++ b/src/tree/node_text.rs
@@ -4,7 +4,7 @@ use std::borrow::Borrow;
 use std::ops::Deref;
 use std::str;
 
-use crlf;
+use crate::crlf;
 
 /// A custom small string.  The unsafe guts of this are in `NodeSmallString`
 /// further down in this file.
@@ -232,9 +232,9 @@ pub(crate) fn fix_segment_seam(l: &mut NodeText, r: &mut NodeText) {
 /// Try to keep this as small as possible, and implement functionality on
 /// NodeText via the safe APIs whenever possible.
 mod inner {
+    use crate::tree::MAX_BYTES;
     use smallvec::{Array, SmallVec};
     use std::{ptr, str};
-    use tree::MAX_BYTES;
 
     /// The backing internal buffer type for `NodeText`.
     #[derive(Copy, Clone)]

--- a/src/tree/node_text.rs
+++ b/src/tree/node_text.rs
@@ -1,5 +1,3 @@
-
-
 use std::borrow::Borrow;
 use std::ops::Deref;
 use std::str;

--- a/src/tree/text_info.rs
+++ b/src/tree/text_info.rs
@@ -1,7 +1,7 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
-use str_utils::{count_chars, count_line_breaks, count_utf16_surrogates};
-use tree::Count;
+use crate::str_utils::{count_chars, count_line_breaks, count_utf16_surrogates};
+use crate::tree::Count;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextInfo {

--- a/tests/clone_rope.rs
+++ b/tests/clone_rope.rs
@@ -27,7 +27,7 @@ fn clone_rope() {
     // Make sure they match
     let matches = Iterator::zip(rope1.chars(), rope2.chars())
         .map(|(a, b)| a == b)
-        .fold(true, |acc, n| acc && n);
+        .all(|n| n);
     assert_eq!(matches, true);
 
     // Insert something into the clone, and make sure they don't match
@@ -35,6 +35,6 @@ fn clone_rope() {
     rope2.insert(3891, "I'm doing fine, thanks!");
     let matches = Iterator::zip(rope1.chars(), rope2.chars())
         .map(|(a, b)| a == b)
-        .fold(true, |acc, n| acc && n);
+        .all(|n| n);
     assert_eq!(matches, false);
 }

--- a/tests/clone_rope_to_thread.rs
+++ b/tests/clone_rope_to_thread.rs
@@ -50,7 +50,7 @@ fn clone_rope_to_thread() {
     let rope2 = rx2.recv().unwrap();
     let matches = Iterator::zip(rope1.chars(), rope2.chars())
         .map(|(a, b)| a == b)
-        .fold(true, |acc, n| acc && n);
+        .all(|n| n);
     assert_eq!(matches, true);
 
     // Send rope2 to the other thread again for more modifications.
@@ -60,6 +60,6 @@ fn clone_rope_to_thread() {
     let rope2 = rx2.recv().unwrap();
     let matches = Iterator::zip(rope1.chars(), rope2.chars())
         .map(|(a, b)| a == b)
-        .fold(true, |acc, n| acc && n);
+        .all(|n| n);
     assert_eq!(matches, false);
 }

--- a/tests/proptest_tests.rs
+++ b/tests/proptest_tests.rs
@@ -596,10 +596,8 @@ proptest! {
         for i in directions {
             if *i == 0 {
                 assert_eq!(itr.prev(), bytes.pop());
-            } else {
-                if let Some(byte) = itr.next() {
-                    bytes.push(byte);
-                }
+            } else if let Some(byte) = itr.next() {
+                bytes.push(byte);
             }
         }
     }
@@ -644,10 +642,8 @@ proptest! {
         for i in directions {
             if *i == 0 {
                 assert_eq!(itr.prev(), chars.pop());
-            } else {
-                if let Some(c) = itr.next() {
-                    chars.push(c);
-                }
+            } else if let Some(c) = itr.next() {
+                chars.push(c);
             }
         }
     }
@@ -716,10 +712,8 @@ proptest! {
         for i in directions {
             if *i == 0 {
                 assert_eq!(itr.prev(), chunks.pop());
-            } else {
-                if let Some(chunk) = itr.next() {
-                    chunks.push(chunk);
-                }
+            } else if let Some(chunk) = itr.next() {
+                chunks.push(chunk);
             }
         }
     }
@@ -741,10 +735,8 @@ proptest! {
         for i in directions {
             if *i == 0 {
                 assert_eq!(itr.prev(), chunks.pop());
-            } else {
-                if let Some(chunk) = itr.next() {
-                    chunks.push(chunk);
-                }
+            } else if let Some(chunk) = itr.next() {
+                chunks.push(chunk);
             }
         }
     }
@@ -779,7 +771,7 @@ proptest! {
         let mut chars_r = r.chars_at(idx);
         let mut chars_t = (&TEXT[char_to_byte_idx(TEXT, idx)..]).chars();
 
-        while let Some(c) = chars_t.next() {
+        for c in chars_t {
             assert_eq!(chars_r.next(), Some(c));
         }
     }
@@ -823,7 +815,7 @@ proptest! {
 
             assert_eq!(byte_count, bytes.len());
 
-            while let Some(_) = bytes.prev() {
+            while bytes.prev().is_some() {
                 byte_count += 1;
                 assert_eq!(byte_count, bytes.len());
             }
@@ -860,7 +852,7 @@ proptest! {
 
         assert_eq!(char_count, chars.len());
 
-        while let Some(_) = chars.prev() {
+        while chars.prev().is_some() {
             char_count += 1;
             assert_eq!(char_count, chars.len());
         }
@@ -896,7 +888,7 @@ proptest! {
 
         assert_eq!(line_count, lines.len());
 
-        while let Some(_) = lines.prev() {
+        while lines.prev().is_some() {
             line_count += 1;
             assert_eq!(line_count, lines.len());
         }

--- a/tests/proptest_tests.rs
+++ b/tests/proptest_tests.rs
@@ -769,7 +769,7 @@ proptest! {
     fn pt_chars_at_01(idx in 0usize..CHAR_LEN) {
         let r = Rope::from_str(TEXT);
         let mut chars_r = r.chars_at(idx);
-        let mut chars_t = (&TEXT[char_to_byte_idx(TEXT, idx)..]).chars();
+        let chars_t = (&TEXT[char_to_byte_idx(TEXT, idx)..]).chars();
 
         for c in chars_t {
             assert_eq!(chars_r.next(), Some(c));


### PR DESCRIPTION
Aside from moving to the latest edition, there are a number of other Clippy warnings I've addressed

- Use pointer casts instead of `std::mem::transmute`
- Use `.cmp` instead of if chains
- Remove unneaded lifetime anotations
- Use `b"..."` instead of `.as_bytes()`
- Use `.is_none()`, `is_some()` and `is_empty()`
- Replace `cfg_attr`
- Use `.next()` instead of `.nth(0)`
- Use `.all()` instead of `.fold()`
- Replace nested `else { if { ` with `else if {`
- Use sugared `for` loop instead of `while let Some(_) = <...>.next()`

