### PR TITLE
smaller total api

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,7 +2,7 @@ use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
 use crate::iter::{Bytes, Chars, Chunks, Lines};
-use crate::rope::Rope;
+use crate::rope::{ Rope, RopeyError };
 use crate::str_utils::{
     byte_to_char_idx, byte_to_line_idx, byte_to_utf16_surrogate_idx, char_to_byte_idx,
     char_to_line_idx, count_chars, count_line_breaks, count_utf16_surrogates, line_to_byte_idx,
@@ -37,6 +37,8 @@ pub(crate) enum RSEnum<'a> {
         line_break_count: Count,
     },
 }
+
+
 
 impl<'a> RopeSlice<'a> {
     pub(crate) fn new_with_range(node: &'a Arc<Node>, start: usize, end: usize) -> Self {
@@ -214,17 +216,10 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
     pub fn byte_to_char(&self, byte_idx: usize) -> usize {
-        // Bounds check
-        assert!(
-            byte_idx <= self.len_bytes(),
-            "Attempt to index past end of slice: byte index {}, slice byte length {}",
-            byte_idx,
-            self.len_bytes()
-        );
-
-        let (chunk, b, c, _) = self.chunk_at_byte(byte_idx);
-        c + byte_to_char_idx(chunk, byte_idx - b)
+        self.try_byte_to_char(byte_idx).unwrap()
     }
+
+
 
     /// Returns the line index of the given byte.
     ///
@@ -268,17 +263,10 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
     pub fn char_to_byte(&self, char_idx: usize) -> usize {
-        // Bounds check
-        assert!(
-            char_idx <= self.len_chars(),
-            "Attempt to index past end of slice: char index {}, slice char length {}",
-            char_idx,
-            self.len_chars()
-        );
-
-        let (chunk, b, c, _) = self.chunk_at_char(char_idx);
-        b + char_to_byte_idx(chunk, char_idx - c)
+        self.try_char_to_byte(char_idx).unwrap()
     }
+
+
 
     /// Returns the line index of the given char.
     ///
@@ -296,17 +284,10 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
     pub fn char_to_line(&self, char_idx: usize) -> usize {
-        // Bounds check
-        assert!(
-            char_idx <= self.len_chars(),
-            "Attempt to index past end of slice: char index {}, slice char length {}",
-            char_idx,
-            self.len_chars()
-        );
-
-        let (chunk, _, c, l) = self.chunk_at_char(char_idx);
-        l + char_to_line_idx(chunk, char_idx - c)
+        self.try_char_to_line(char_idx).unwrap()
     }
+
+
 
     /// Returns the utf16 code unit index of the given char.
     ///
@@ -453,21 +434,10 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
     pub fn line_to_char(&self, line_idx: usize) -> usize {
-        // Bounds check
-        assert!(
-            line_idx <= self.len_lines(),
-            "Attempt to index past end of slice: line index {}, slice line length {}",
-            line_idx,
-            self.len_lines()
-        );
-
-        if line_idx == self.len_lines() {
-            self.len_chars()
-        } else {
-            let (chunk, _, c, l) = self.chunk_at_line_break(line_idx);
-            c + line_to_char_idx(chunk, line_idx - l)
-        }
+        self.try_line_to_char(line_idx).unwrap()
     }
+
+
 
     //-----------------------------------------------------------------------
     // Fetch methods
@@ -503,18 +473,18 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx >= len_chars()`).
     #[inline]
     pub fn char(&self, char_idx: usize) -> char {
-        // Bounds check
-        assert!(
-            char_idx < self.len_chars(),
-            "Attempt to index past end of slice: char index {}, slice char length {}",
-            char_idx,
-            self.len_chars()
-        );
-
-        let (chunk, _, chunk_char_idx, _) = self.chunk_at_char(char_idx);
-        let byte_idx = char_to_byte_idx(chunk, char_idx - chunk_char_idx);
-        chunk[byte_idx..].chars().next().unwrap()
+        if let Some(out) = self.get_char(char_idx) {
+            out
+        } else {
+            panic!(
+                "Attempt to index past end of slice: char index {}, slice char length {}",
+                char_idx,
+                self.len_chars()
+            );
+        }
     }
+
+
 
     /// Returns the line at `line_idx`.
     ///
@@ -527,33 +497,19 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx >= len_lines()`).
     #[inline]
     pub fn line(&self, line_idx: usize) -> RopeSlice<'a> {
-        let len_lines = self.len_lines();
-
-        // Bounds check
-        assert!(
-            line_idx < len_lines,
-            "Attempt to index past end of slice: line index {}, slice line length {}",
-            line_idx,
-            len_lines
-        );
-
-        let (chunk_1, _, c1, l1) = self.chunk_at_line_break(line_idx);
-        let (chunk_2, _, c2, l2) = self.chunk_at_line_break(line_idx + 1);
-        if c1 == c2 {
-            let text1 = &chunk_1[line_to_byte_idx(chunk_1, line_idx - l1)..];
-            let text2 = &text1[..line_to_byte_idx(text1, 1)];
-            RopeSlice(RSEnum::Light {
-                text: text2,
-                char_count: count_chars(text2) as Count,
-                utf16_surrogate_count: count_utf16_surrogates(text2) as Count,
-                line_break_count: if line_idx == (len_lines - 1) { 0 } else { 1 },
-            })
+        if let Some(out) = self.get_line(line_idx) {
+            out
         } else {
-            let start = c1 + line_to_char_idx(chunk_1, line_idx - l1);
-            let end = c2 + line_to_char_idx(chunk_2, line_idx + 1 - l2);
-            self.slice(start..end)
+            let len_lines = self.len_lines();
+            panic!(
+                "Attempt to index past end of slice: line index {}, slice line length {}",
+                line_idx,
+                len_lines
+            );
         }
     }
+
+
 
     /// Returns the chunk containing the given byte index.
     ///
@@ -572,42 +528,10 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     pub fn chunk_at_byte(&self, byte_idx: usize) -> (&'a str, usize, usize, usize) {
-        // Bounds check
-        assert!(
-            byte_idx <= self.len_bytes(),
-            "Attempt to index past end of slice: byte index {}, slice byte length {}",
-            byte_idx,
-            self.len_bytes()
-        );
-
-        match *self {
-            RopeSlice(RSEnum::Full {
-                node,
-                start_info,
-                end_info,
-            }) => {
-                // Get the chunk.
-                let (chunk, chunk_start_info) =
-                    node.get_chunk_at_byte(byte_idx + start_info.bytes as usize);
-
-                // Calculate clipped start/end byte indices within the chunk.
-                let chunk_start_byte_idx = start_info.bytes.saturating_sub(chunk_start_info.bytes);
-                let chunk_end_byte_idx =
-                    (chunk.len() as Count).min(end_info.bytes - chunk_start_info.bytes);
-
-                // Return the clipped chunk and byte offset.
-                (
-                    &chunk[chunk_start_byte_idx as usize..chunk_end_byte_idx as usize],
-                    chunk_start_info.bytes.saturating_sub(start_info.bytes) as usize,
-                    chunk_start_info.chars.saturating_sub(start_info.chars) as usize,
-                    chunk_start_info
-                        .line_breaks
-                        .saturating_sub(start_info.line_breaks) as usize,
-                )
-            }
-            RopeSlice(RSEnum::Light { text, .. }) => (text, 0, 0, 0),
-        }
+        self.try_chunk_at_byte(byte_idx).unwrap()
     }
+
+
 
     /// Returns the chunk containing the given char index.
     ///
@@ -809,6 +733,8 @@ impl<'a> RopeSlice<'a> {
         }
     }
 
+
+
     //-----------------------------------------------------------------------
     // Iterator methods
 
@@ -912,33 +838,17 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
     pub fn chars_at(&self, char_idx: usize) -> Chars {
-        // Bounds check
-        assert!(
-            char_idx <= self.len_chars(),
-            "Attempt to index past end of RopeSlice: char index {}, RopeSlice char length {}",
-            char_idx,
-            self.len_chars()
-        );
-
-        match *self {
-            RopeSlice(RSEnum::Full {
-                node,
-                start_info,
-                end_info,
-            }) => Chars::new_with_range_at(
-                node,
-                start_info.chars as usize + char_idx,
-                (start_info.bytes as usize, end_info.bytes as usize),
-                (start_info.chars as usize, end_info.chars as usize),
-                (
-                    start_info.line_breaks as usize,
-                    end_info.line_breaks as usize + 1,
-                ),
-            ),
-
-            RopeSlice(RSEnum::Light { text, .. }) => Chars::from_str_at(text, char_idx),
+        if let Some(out) = self.get_chars_at(char_idx) {
+            out
+        } else {
+            panic!(
+                "Attempt to index past end of RopeSlice: char index {}, RopeSlice char length {}",
+                char_idx,
+                self.len_chars()
+            );
         }
     }
+
 
     /// Creates an iterator over the lines of the `RopeSlice`.
     ///
@@ -1278,6 +1188,226 @@ impl<'a> RopeSlice<'a> {
         }
     }
 }
+
+impl<'a> RopeSlice<'a> {
+    /// a total version of [`byte_to_char`]
+    ///
+    /// [`byte_to_char`]: RopeSlice::byte_to_char
+    #[inline]
+    pub fn try_byte_to_char(&self, byte_idx: usize) -> Result<usize, RopeyError> {
+        // Bounds check
+        if byte_idx <= self.len_bytes() {
+            let (chunk, b, c, _) = self.chunk_at_byte(byte_idx);
+            Ok(c + byte_to_char_idx(chunk, byte_idx - b))
+        } else {
+            Err(RopeyError::SliceIndexByte(byte_idx, self.len_bytes()))
+        }
+    }
+    
+    /// a total version of [`char_to_byte`]
+    ///
+    /// [`char_to_byte`]: RopeSlice::char_to_byte
+    #[inline]
+    pub fn try_char_to_byte(&self, char_idx: usize) -> Result<usize, RopeyError> {
+        // Bounds check
+        if char_idx <= self.len_chars() {
+            let (chunk, b, c, _) = self.chunk_at_char(char_idx);
+            Ok(b + char_to_byte_idx(chunk, char_idx - c))
+        } else {
+            Err(RopeyError::SliceIndexChar(char_idx, self.len_chars()))
+        }
+    }
+    
+    /// a total version of [`char_to_line`]
+    ///
+    /// [`char_to_line`]: RopeSlice::char_to_line
+    #[inline]
+    pub fn try_char_to_line(&self, char_idx: usize) -> Result<usize, RopeyError> {
+        // Bounds check
+        if char_idx <= self.len_chars() {
+            let (chunk, _, c, l) = self.chunk_at_char(char_idx);
+            Ok(l + char_to_line_idx(chunk, char_idx - c))
+        } else {
+            Err(RopeyError::SliceIndexChar(char_idx, self.len_chars()))
+        }
+    }
+    
+    /// a total version of [`line_to_char`]
+    ///
+    /// [`line_to_char`]: RopeSlice::line_to_char
+    #[inline]
+    pub fn try_line_to_char(&self, line_idx: usize) -> Result<usize, RopeyError> {
+        // Bounds check
+        if line_idx <= self.len_lines() {
+            if line_idx == self.len_lines() {
+                Ok(self.len_chars())
+            } else {
+                let (chunk, _, c, l) = self.chunk_at_line_break(line_idx);
+                Ok(c + line_to_char_idx(chunk, line_idx - l))
+            }
+        } else {
+            Err(RopeyError::SliceIndexLine(line_idx, self.len_lines()))
+        }
+    }
+    
+    /// a total version of [`char`]
+    ///
+    /// [`char`]: RopeSlice::char
+    #[inline]
+    pub fn get_char(&self, char_idx: usize) -> Option<char> {
+        // Bounds check
+        if char_idx < self.len_chars() {
+            let (chunk, _, chunk_char_idx, _) = self.chunk_at_char(char_idx);
+            let byte_idx = char_to_byte_idx(chunk, char_idx - chunk_char_idx);
+            Some(chunk[byte_idx..].chars().next().unwrap())
+        } else {
+            None
+        }
+    }
+    
+    /// a total version of [`line`]
+    ///
+    /// [`line`]: RopeSlice::line
+    #[inline]
+    pub fn get_line(&self, line_idx: usize) -> Option<RopeSlice<'a>> {
+        let len_lines = self.len_lines();
+        // Bounds check
+        if line_idx < len_lines {
+            let (chunk_1, _, c1, l1) = self.chunk_at_line_break(line_idx);
+            let (chunk_2, _, c2, l2) = self.chunk_at_line_break(line_idx + 1);
+            if c1 == c2 {
+                let text1 = &chunk_1[line_to_byte_idx(chunk_1, line_idx - l1)..];
+                let text2 = &text1[..line_to_byte_idx(text1, 1)];
+                Some(RopeSlice(RSEnum::Light {
+                    text: text2,
+                    char_count: count_chars(text2) as Count,
+                    utf16_surrogate_count: count_utf16_surrogates(text2) as Count,
+                    line_break_count: if line_idx == (len_lines - 1) { 0 } else { 1 },
+                }))
+            } else {
+                let start = c1 + line_to_char_idx(chunk_1, line_idx - l1);
+                let end = c2 + line_to_char_idx(chunk_2, line_idx + 1 - l2);
+                Some(self.slice(start..end))
+            }
+        } else {
+            None
+        }
+    }
+    
+    /// a total version of [`chunk_at_byte`]
+    ///
+    /// [`chunk_at_byte`]: RopeSlice::chunk_at_byte
+    pub fn try_chunk_at_byte(&self, byte_idx: usize) -> Result<(&'a str, usize, usize, usize), RopeyError> {
+        // Bounds check
+        if byte_idx <= self.len_bytes() {
+            match *self {
+                RopeSlice(RSEnum::Full {
+                    node,
+                    start_info,
+                    end_info,
+                }) => {
+                    // Get the chunk.
+                    let (chunk, chunk_start_info) =
+                        node.get_chunk_at_byte(byte_idx + start_info.bytes as usize);
+
+                    // Calculate clipped start/end byte indices within the chunk.
+                    let chunk_start_byte_idx = start_info.bytes.saturating_sub(chunk_start_info.bytes);
+                    let chunk_end_byte_idx =
+                        (chunk.len() as Count).min(end_info.bytes - chunk_start_info.bytes);
+
+                    // Return the clipped chunk and byte offset.
+                    Ok((
+                        &chunk[chunk_start_byte_idx as usize..chunk_end_byte_idx as usize],
+                        chunk_start_info.bytes.saturating_sub(start_info.bytes) as usize,
+                        chunk_start_info.chars.saturating_sub(start_info.chars) as usize,
+                        chunk_start_info
+                            .line_breaks
+                            .saturating_sub(start_info.line_breaks) as usize,
+                    ))
+                }
+                RopeSlice(RSEnum::Light { text, .. }) => Ok((text, 0, 0, 0)),
+            }
+        } else {
+            Err(RopeyError::SliceIndexByte(byte_idx, self.len_bytes()))
+        }
+    }
+    
+    pub fn get_slice<R>(&self, char_range: R) -> Option<Self>
+    where
+        R: RangeBounds<usize>,
+    {
+        let (start, end) = {
+            let start_range = start_bound_to_num(char_range.start_bound());
+            let end_range = end_bound_to_num(char_range.end_bound());
+
+            // Early-out shortcut for taking a slice of the full thing.
+            if start_range == None && end_range == None {
+                return Some(*self);
+            }
+
+            (
+                start_range.unwrap_or(0),
+                end_range.unwrap_or_else(|| self.len_chars()),
+            )
+        };
+
+        // Bounds check
+        if start <= end && end <= self.len_chars() {
+            match *self {
+                RopeSlice(RSEnum::Full {
+                    node, start_info, ..
+                }) => Some(RopeSlice::new_with_range(
+                    node,
+                    start_info.chars as usize + start,
+                    start_info.chars as usize + end,
+                )),
+                RopeSlice(RSEnum::Light { text, .. }) => {
+                    let start_byte = char_to_byte_idx(text, start);
+                    let end_byte = char_to_byte_idx(text, end);
+                    let new_text = &text[start_byte..end_byte];
+                    Some(RopeSlice(RSEnum::Light {
+                        text: new_text,
+                        char_count: (end - start) as Count,
+                        utf16_surrogate_count: count_utf16_surrogates(new_text) as Count,
+                        line_break_count: count_line_breaks(new_text) as Count,
+                    }))
+                }
+            }
+        } else {
+            None
+        }
+    }
+    
+    /// a total version of [`chars_at`]
+    ///
+    /// [`chars_at`]: RopeSlice::chars_at
+    #[inline]
+    pub fn get_chars_at(&self, char_idx: usize) -> Option<Chars> {
+        // Bounds check
+        if char_idx <= self.len_chars() {
+            match *self {
+                RopeSlice(RSEnum::Full {
+                    node,
+                    start_info,
+                    end_info,
+                }) => Some(Chars::new_with_range_at(
+                    node,
+                    start_info.chars as usize + char_idx,
+                    (start_info.bytes as usize, end_info.bytes as usize),
+                    (start_info.chars as usize, end_info.chars as usize),
+                    (
+                        start_info.line_breaks as usize,
+                        end_info.line_breaks as usize + 1,
+                    ),
+                )),
+                RopeSlice(RSEnum::Light { text, .. }) => Some(Chars::from_str_at(text, char_idx)),
+            }
+        } else {
+            None
+        }
+    }
+}
+
 
 //==============================================================
 


### PR DESCRIPTION
The error style is sort of verbose, but there were some practical considerations that made something like this seem better than the alternatives. Users will probably only want one error type while retaining the more detailed messages, but I didn't want to do anything stringly typed.

The total versions are in their own `impl` blocks, and where it would retain the error reporting, the partial versions are just defined as the `total().unwrap()`.