### PR TITLE
fix Hash implementation

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,3 +24,9 @@ name = "mutation"
 path = "fuzz_targets/mutation.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "hash"
+path = "fuzz_targets/hash.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/hash.rs
+++ b/fuzz/fuzz_targets/hash.rs
@@ -1,0 +1,113 @@
+#![no_main]
+
+use libfuzzer_sys::{
+    arbitrary::{self, Arbitrary},
+    fuzz_target,
+};
+use ropey::Rope;
+use std::hash::{Hasher, Hash};
+
+const SMALL_TEXT: &str = include_str!("small.txt");
+
+/// This is an example `Hasher` to demonstrate a property guaranteed by
+/// the documentation that is not exploited by the default `Hasher` (SipHash)
+/// Relevant excerpt from the `Hasher` documentation:
+/// > Nor can you assume that adjacent
+/// > `write` calls are merged, so it's possible, for example, that
+/// > ```
+/// > # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// > hasher.write(&[1, 2]);
+/// > hasher.write(&[3, 4, 5, 6]);
+/// > # }
+/// > ```
+/// > and
+/// > ```
+/// > # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// > hasher.write(&[1, 2, 3, 4]);
+/// > hasher.write(&[5, 6]);
+/// > # }
+/// > ```
+/// > end up producing different hashes.
+///
+/// This dummy hasher simply collects all bytes and inserts a separator byte (0xFF) at the end of `write`.
+/// While this hasher might seem a little silly, it is perfectly inline with the std documentation.
+/// Many other commonly used high performance `Hasher`s (fxhash, ahash, fnvhash) exploit the same property
+/// to improve the performance of `write`, so violating this property will cause issues in practice.
+#[derive(Default)]
+struct TestHasher(std::collections::hash_map::DefaultHasher);
+impl Hasher for TestHasher {
+    fn finish(&self) -> u64 {
+        self.0.finish() 
+   }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes);
+        self.0.write_u8(0xFF);
+    }
+}
+
+#[derive(Arbitrary, Copy, Clone, Debug)]
+enum Op<'a> {
+    Insert(usize, &'a str),
+    InsertChar(usize, char),
+    Remove(usize, usize),
+    SplitOff(usize, bool),
+    Append(&'a str),
+}
+
+#[derive(Arbitrary, Copy, Clone, Debug)]
+enum StartingText<'a> {
+    Small,
+    Custom(&'a str),
+}
+
+fuzz_target!(|data: (StartingText, Vec<Op>)| {
+    let mut r = Rope::from_str(match data.0 {
+        StartingText::Small => SMALL_TEXT,
+        StartingText::Medium => MEDIUM_TEXT,
+        StartingText::Custom(s) => s,
+    });
+
+    for op in data.1 {
+        match op {
+            Op::Insert(idx, s) => {
+                let _ = r.try_insert(idx, s);
+            }
+            Op::InsertChar(idx, c) => {
+                let _ = r.try_insert_char(idx, c);
+            }
+            Op::Remove(idx_1, idx_2) => {
+                let _ = r.try_remove(idx_1..idx_2);
+            }
+            Op::SplitOff(idx, keep_right) => match r.try_split_off(idx) {
+                Ok(right) => {
+                    if keep_right {
+                        r = right;
+                    }
+                }
+                Err(_) => {}
+            },
+            Op::Append(s) => {
+                r.append(Rope::from_str(s));
+            }
+        }
+    }
+
+    r.assert_integrity();
+    r.assert_invariants();
+    
+    
+
+    // shift chunk bounderies
+
+    let r2 = Rope::from_str(&r.to_string()); 
+    for (line1, line2) in r.lines().zip(r2.lines()) {
+        let mut hasher1 = TestHasher::default();
+        let mut hasher2 = TestHasher::default();
+        line1.hash(&mut hasher1);    
+        line2.hash(&mut hasher2);
+        if hasher1.finish() != hasher2.finish(){
+            assert_ne!(line1, line2)
+        }
+    }
+});

--- a/tests/hash.rs
+++ b/tests/hash.rs
@@ -1,0 +1,71 @@
+extern crate ropey;
+
+use std::hash::{Hash, Hasher};
+
+use ropey::Rope;
+
+const SMALL_TEXT: &str = include_str!("small.txt");
+
+/// This is an example `Hasher` to demonstrate a property guaranteed by
+/// the documentation that is not exploited by the default `Hasher` (SipHash)
+/// Relevant excerpt from the `Hasher` documentation:
+/// > Nor can you assume that adjacent
+/// > `write` calls are merged, so it's possible, for example, that
+/// > ```
+/// > # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// > hasher.write(&[1, 2]);
+/// > hasher.write(&[3, 4, 5, 6]);
+/// > # }
+/// > ```
+/// > and
+/// > ```
+/// > # fn foo(hasher: &mut impl std::hash::Hasher) {
+/// > hasher.write(&[1, 2, 3, 4]);
+/// > hasher.write(&[5, 6]);
+/// > # }
+/// > ```
+/// > end up producing different hashes.
+/// 
+/// This dummy hasher simply collects all bytes and inserts a separator byte (0xFF) at the end of `write`.
+/// While this hasher might seem a little silly, it is perfectly inline with the std documentation.
+/// Many other commonly used high performance `Hasher`s (fxhash, ahash, fnvhash) exploit the same property
+/// to improve the performance of `write`, so violating this property will cause issues in practice.
+#[derive(Default)]
+struct TestHasher(std::collections::hash_map::DefaultHasher);
+impl Hasher for TestHasher {
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes);
+        self.0.write_u8(0xFF);
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn hash_1() {
+    // Build rope from file contents
+    let mut r = Rope::from_str(SMALL_TEXT);
+
+    r.insert(0, "\0");
+    // Verify rope integrity
+    r.assert_integrity();
+    r.assert_invariants();
+
+    check_line_hashes(r)
+}
+
+fn check_line_hashes(r: Rope) {
+    let r2 = Rope::from_str(&r.to_string());
+    for (line1, line2) in r.lines().zip(r2.lines()) {
+        let mut hasher1 = TestHasher::default();
+        let mut hasher2 = TestHasher::default();
+        line1.hash(&mut hasher1);
+        line2.hash(&mut hasher2);
+        if hasher1.finish() != hasher2.finish() {
+            assert_ne!(line1, line2)
+        }
+    }
+}

--- a/tests/non_ascii_comparison.rs
+++ b/tests/non_ascii_comparison.rs
@@ -23,6 +23,7 @@ fn non_ascii_eq() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn non_ascii_ord() {
     // Build rope from file contents
     let rope1 = Rope::from_str(TEXT1);

--- a/tests/small.txt
+++ b/tests/small.txt
@@ -1,0 +1,24 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet tellus 
+nec turpis feugiat semper. Nam at nulla laoreet, finibus eros sit amet, fringilla 
+mauris. Fusce vestibulum nec ligula efficitur laoreet. Nunc orci leo, varius eget 
+ligula vulputate, consequat eleifend nisi. Cras justo purus, imperdiet a augue 
+malesuada, convallis cursus libero. Fusce pretium arcu in elementum laoreet. Duis 
+mauris nulla, suscipit at est nec, malesuada pellentesque eros. Quisque semper porta 
+malesuada. Nunc hendrerit est ac faucibus mollis. Nam fermentum id libero sed 
+egestas. Duis a accumsan sapien. Nam neque diam, congue non erat et, porta sagittis 
+turpis. Vivamus vitae mauris sit amet massa mollis molestie. Morbi scelerisque, 
+augue id congue imperdiet, felis lacus euismod dui, vitae facilisis massa dui quis 
+sapien. Vivamus hendrerit a urna a lobortis.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet tellus 
+nec turpis feugiat semper. Nam at nulla laoreet, finibus eros sit amet, fringilla 
+mauris. Fusce vestibulum nec ligula efficitur laoreet. Nunc orci leo, varius eget 
+ligula vulputate, consequat eleifend nisi. Cras justo purus, imperdiet a augue 
+malesuada, convallis cursus libero. Fusce pretium arcu in elementum laoreet. Duis 
+mauris nulla, suscipit at est nec, malesuada pellentesque eros. Quisque semper porta 
+malesuada. Nunc hendrerit est ac faucibus mollis. Nam fermentum id libero sed 
+egestas. Duis a accumsan sapien. Nam neque diam, congue non erat et, porta sagittis 
+turpis. Vivamus vitae mauris sit amet massa mollis molestie. Morbi scelerisque, 
+augue id congue imperdiet, felis lacus euismod dui, vitae facilisis massa dui quis 
+sapien. Vivamus hendrerit a urna a lobortis.
+


### PR DESCRIPTION
The current `Hash` implementation of `Ropey` violates the
std API contract and therefore breaks with most non-default `Hasher`s.

Ropeys current `Hash` implementation simply hashes all chunks in a loop.
However, this means that the chunk boundries are encoded into the `Hash`.
From the documentation of `Hasher`:

> This trait provides no guarantees about how the various `write_*` methods are
> defined and implementations of [`Hash`] should not assume that they work one
> way or another. You cannot assume, for example, that a [`write_u32`] call is
> equivalent to four calls of [`write_u8`].  Nor can you assume that adjacent
> `write` calls are merged, so it's possible, for example, that
> ```
> # fn foo(hasher: &mut impl std::hash::Hasher) {
> hasher.write(&[1, 2]);
> hasher.write(&[3, 4, 5, 6]);
> # }
> ```
> and
> ```
> # fn foo(hasher: &mut impl std::hash::Hasher) {
> hasher.write(&[1, 2, 3, 4]);
> hasher.write(&[5, 6]);
> # }
> ```
> end up producing different hashes.
>
> Thus to produce the same hash value, [`Hash`] implementations must ensure
> for equivalent items that exactly the same sequence of calls is made -- the
> same methods with the same parameters in the same order.

This means that no matter what the chunk boundaries are, the same `write` calls must happen.
The tests did not catch this because the default `Hasher` does not exploit this property.
However, most other `Hasher`s with less strong guarantees about dos resistance (`ahash`, `fxhash`, `fnvhash`)
do exploit this property.
The default `Hasher` may also start to exploit this property at any point in the future (and it would not be considered a breaking change by std).
When using such a `Hasher` with ropey the property `hash(rope1) != hash(rope2) <=> rope1 != rope2` does
not hold anymore. This leads to `HashMap`s with the same key present multiple times (or failed lookups when the key does exist).

The simplest fix for this is simply to call `write_u8` for each byte of the chunk.
However, this is extremely slow, because `Hashers` usually heavily optimize batch operations.
For example for `ahash` this is at least 16 times slower, because it always operates on 16 bytes at once.

Instead, I have created a hash implementation that uses a temporary buffer to divide
the bytes of the ropes into slices with length `BYTES_MIN` (except the last slice which may be smaller) and passes those to the `Hasher`.
This causes a bit of overhead as some bytes need to be copied at the chunk boundaries. 
However, the overhead should be much smaller than calling `write_u8` repeatedly and should only degrade performance slightly 




