### PR TITLE
correcly fixup tree when a removal occurs at the chunk boundery

### DIFF
--- a/tests/fix_tree.rs
+++ b/tests/fix_tree.rs
@@ -1,0 +1,18 @@
+extern crate ropey;
+
+use ropey::Rope;
+
+const MEDIUM_TEXT: &str = include_str!("medium.txt");
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn remove_at_chunk_boundery() {
+    let mut r = Rope::from_str(MEDIUM_TEXT);
+    // remove exactly at a chunk boundry
+    // to trigger an edgecase in fix_tree_seam
+    r.remove(31354..58881);
+
+    // Verify rope integrity
+    r.assert_integrity();
+    r.assert_invariants();
+}


### PR DESCRIPTION
While fuzzing #66 I found a case where the tree ends up in an invalid state
after a call to `remove` (see test case with this PR).


`fix_tree_seam` incorrectly handled the case of a removal happens exactly at the chunk boundary.
While the implementation did in fact consider that edge case, the detection was incorrect:
It checked whether the current character was equal to the end of the child.
However, in that case `search_char_idx` would return the next child (the end is exclusive).
To fix the problem I changed `fix_tree_seam` to check for `start_info.chart == char_idx` instead (and to check the previous child instead of the next one).

