### PR TITLE
better fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ cr_lines = [] # Enable recognizing carriage returns as line breaks.
 unicode_lines = ["cr_lines"] # Enable recognizing all Unicode line breaks.
 simd = ["str_indices/simd"]
 
+# Internal feature: Not part of public stable API
+# enables a much smaller chunk size that makes it
+# easier to catch bugs without requiring huge text sizes during fuzzing.
+small_chunks = []
+
 [dependencies]
 smallvec = "1.0.0"
 str_indices = { version = "0.4.0", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,12 +15,23 @@ libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 [dependencies.ropey]
 path = ".."
 
+[features]
+small_chunks = ["ropey/small_chunks"]
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
 
 [[bin]]
 name = "mutation"
 path = "fuzz_targets/mutation.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "mutation_small_chunks"
+path = "fuzz_targets/mutation_small_chunks.rs"
+test = false
+doc = false
+required-features = ["small_chunks"]

--- a/fuzz/fuzz_targets/mutation_small_chunks.rs
+++ b/fuzz/fuzz_targets/mutation_small_chunks.rs
@@ -1,0 +1,59 @@
+#![no_main]
+
+use libfuzzer_sys::{
+    arbitrary::{self, Arbitrary},
+    fuzz_target,
+};
+use ropey::Rope;
+
+const SMALL_TEXT: &str = include_str!("small.txt");
+
+#[derive(Arbitrary, Copy, Clone, Debug)]
+enum Op<'a> {
+    Insert(usize, &'a str),
+    InsertChar(usize, char),
+    Remove(usize, usize),
+    SplitOff(usize, bool),
+    Append(&'a str),
+}
+
+#[derive(Arbitrary, Copy, Clone, Debug)]
+enum StartingText<'a> {
+    Small,
+    Custom(&'a str),
+}
+
+fuzz_target!(|data: (StartingText, Vec<Op>)| {
+    let mut r = Rope::from_str(match data.0 {
+        StartingText::Small => SMALL_TEXT,
+        StartingText::Custom(s) => s,
+    });
+
+    for op in data.1 {
+        match op {
+            Op::Insert(idx, s) => {
+                let _ = r.try_insert(idx, s);
+            }
+            Op::InsertChar(idx, c) => {
+                let _ = r.try_insert_char(idx, c);
+            }
+            Op::Remove(idx_1, idx_2) => {
+                let _ = r.try_remove(idx_1..idx_2);
+            }
+            Op::SplitOff(idx, keep_right) => match r.try_split_off(idx) {
+                Ok(right) => {
+                    if keep_right {
+                        r = right;
+                    }
+                }
+                Err(_) => {}
+            },
+            Op::Append(s) => {
+                r.append(Rope::from_str(s));
+            }
+        }
+    }
+
+    r.assert_integrity();
+    r.assert_invariants();
+});

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use self::text_info::TextInfo;
 pub(crate) type Count = u64;
 
 // Real constants used in release builds.
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "small_chunks")))]
 mod constants {
     use super::{Node, TextInfo};
     use smallvec::SmallVec;
@@ -90,7 +90,7 @@ mod constants {
 // Smaller constants used in debug builds.  These are different from release
 // in order to trigger deeper trees without having to use huge text data in
 // the tests.
-#[cfg(test)]
+#[cfg(any(test, feature = "small_chunks"))]
 mod test_constants {
     pub(crate) const MAX_CHILDREN: usize = 5;
     pub(crate) const MIN_CHILDREN: usize = MAX_CHILDREN / 2;
@@ -100,8 +100,8 @@ mod test_constants {
     pub(crate) const MIN_BYTES: usize = (MAX_BYTES / 2) - (MAX_BYTES / 32);
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "small_chunks")))]
 pub(crate) use self::constants::{MAX_BYTES, MAX_CHILDREN, MIN_BYTES, MIN_CHILDREN};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "small_chunks"))]
 pub(crate) use self::test_constants::{MAX_BYTES, MAX_CHILDREN, MIN_BYTES, MIN_CHILDREN};


### PR DESCRIPTION
While working on #66 I fuzzed the hash implementation.
I noticed that the fuzzer took extremely long to find any results, because chunk boundaries are quite rare (so huge strings are required).
By using `cfg(fuzzing)` in addition to `cfg(test)` for enabling a much smaller fuzz size, chunk sizes are much more common and the
fuzzer finds problems much quicker.
For example with the change the bug from #67 is quickly detected.
I have removed the `medium.txt` case from the fuzzer because it slows the fuzzing to a crawl due to the huge amount of chunks.
I think the main point of the file was to test chunk boundaries anyway which now also occur for `small.txt` and randomly generated text.