### PR TITLE
fix medium.txt path in test case

### DIFF
--- a/tests/fix_tree.rs
+++ b/tests/fix_tree.rs
@@ -2,7 +2,7 @@ extern crate ropey;
 
 use ropey::Rope;
 
-const MEDIUM_TEXT: &str = include_str!("medium.txt");
+const MEDIUM_TEXT: &str = include_str!("../benches/medium.txt");
 
 #[test]
 #[cfg_attr(miri, ignore)]


### PR DESCRIPTION
When I clone the project and run cargo test, it failed to compile with error: 

```bash
5 | const MEDIUM_TEXT: &str = include_str!("medium.txt");
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
```