### PR TITLE
Fix Line Iterator creation for empty Rope

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -620,7 +620,7 @@ impl<'a> Lines<'a> {
                 is_reversed: false,
                 byte_idx: 0,
                 line_idx: 0,
-                total_lines: 0,
+                total_lines: 1,
             };
         }
 
@@ -3521,5 +3521,13 @@ mod tests {
         for _ in 0..8 {
             assert_eq!(stack.pop(), itr.next());
         }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn empty_iter() {
+        let rope = Rope::from_str("");
+        let r: Vec<_> = rope.lines().collect();
+        assert_eq!(&[""], &*r)
     }
 }


### PR DESCRIPTION
Fixes #76.

In #70 I introduced a small oversight in the edge case of an empty `Rope`.
I initialized the `Lines` iterator with `total_lines = 0`.
However, the `Lines` iterator always yields atleast a single line (even if that line is empty)
which caused the subsequent underflow.
This PR fixes that by setting `total_lines = 1` in the appropriate edge case.
I also added a test case to make sure this doesn't regress in the future.