### PR TITLE
Implement two-way iterators and peekables

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -73,6 +73,7 @@ use crate::str_utils::{
     last_line_start_byte_idx, line_to_byte_idx, trim_line_break,
 };
 use crate::tree::{Count, Node, TextInfo};
+use crate::two_way_peekable::{TwoWayIterator, TwoWayPeekable};
 
 //==========================================================
 
@@ -211,16 +212,20 @@ impl<'a> Bytes<'a> {
         self
     }
 
+    /// Return peekable version of the iterator
+    #[inline(always)]
+    pub fn two_way_peekable(self) -> TwoWayPeekable<Self> {
+        // this is needed, so that users can call `.two_way_peekable()` without importing TwoWayIterator
+        TwoWayIterator::two_way_peekable(self)
+    }
+
     /// Advances the iterator backwards and returns the previous value.
     ///
     /// Runs in amortized O(1) time and worst-case O(log N) time.
     #[inline(always)]
     pub fn prev(&mut self) -> Option<u8> {
-        if !self.is_reversed {
-            self.prev_impl()
-        } else {
-            self.next_impl()
-        }
+        // this is needed, so that users can call `.prev()` without importing TwoWayIterator
+        TwoWayIterator::prev(self)
     }
 
     #[inline]
@@ -295,6 +300,16 @@ impl<'a> Iterator for Bytes<'a> {
             self.bytes_total - self.bytes_remaining
         };
         (remaining, Some(remaining))
+    }
+}
+
+impl<'a> TwoWayIterator for Bytes<'a> {
+    fn prev(&mut self) -> Option<Self::Item> {
+        if !self.is_reversed {
+            self.prev_impl()
+        } else {
+            self.next_impl()
+        }
     }
 }
 
@@ -441,16 +456,20 @@ impl<'a> Chars<'a> {
         self
     }
 
+    /// Return peekable version of the iterator
+    #[inline(always)]
+    pub fn two_way_peekable(self) -> TwoWayPeekable<Self> {
+        // this is needed, so that users can call `.two_way_peekable()` without importing TwoWayIterator
+        TwoWayIterator::two_way_peekable(self)
+    }
+
     /// Advances the iterator backwards and returns the previous value.
     ///
     /// Runs in amortized O(1) time and worst-case O(log N) time.
     #[inline(always)]
     pub fn prev(&mut self) -> Option<char> {
-        if !self.is_reversed {
-            self.prev_impl()
-        } else {
-            self.next_impl()
-        }
+        // this is needed, so that users can call `.prev()` without importing TwoWayIterator
+        TwoWayIterator::prev(self)
     }
 
     #[inline]
@@ -533,6 +552,20 @@ impl<'a> Iterator for Chars<'a> {
             self.chars_total - self.chars_remaining
         };
         (remaining, Some(remaining))
+    }
+}
+
+impl<'a> TwoWayIterator for Chars<'a> {
+    /// Advances the iterator backwards and returns the previous value.
+    ///
+    /// Runs in amortized O(1) time and worst-case O(log N) time.
+    #[inline(always)]
+    fn prev(&mut self) -> Option<Self::Item> {
+        if !self.is_reversed {
+            self.prev_impl()
+        } else {
+            self.next_impl()
+        }
     }
 }
 
@@ -751,17 +784,20 @@ impl<'a> Lines<'a> {
         self
     }
 
+    /// Return peekable version of the iterator
+    #[inline(always)]
+    pub fn two_way_peekable(self) -> TwoWayPeekable<Self> {
+        // this is needed, so that users can call `.two_way_peekable()` without importing TwoWayIterator
+        TwoWayIterator::two_way_peekable(self)
+    }
+
     /// Advances the iterator backwards and returns the previous value.
     ///
-    /// Runs in O(1) time with respect to rope length and O(N) time with
-    /// respect to line length.
+    /// Runs in amortized O(1) time and worst-case O(log N) time.
     #[inline(always)]
     pub fn prev(&mut self) -> Option<RopeSlice<'a>> {
-        if self.is_reversed {
-            self.next_impl()
-        } else {
-            self.prev_impl()
-        }
+        // this is needed, so that users can call `.prev()` without importing TwoWayIterator
+        TwoWayIterator::prev(self)
     }
 
     fn prev_impl(&mut self) -> Option<RopeSlice<'a>> {
@@ -1244,6 +1280,16 @@ impl<'a> Iterator for Lines<'a> {
     }
 }
 
+impl<'a> TwoWayIterator for Lines<'a> {
+    fn prev(&mut self) -> Option<Self::Item> {
+        if !self.is_reversed {
+            self.prev_impl()
+        } else {
+            self.next_impl()
+        }
+    }
+}
+
 impl ExactSizeIterator for Lines<'_> {}
 
 //==========================================================
@@ -1535,16 +1581,20 @@ impl<'a> Chunks<'a> {
         self
     }
 
+    /// Return peekable version of the iterator
+    #[inline(always)]
+    pub fn two_way_peekable(self) -> TwoWayPeekable<Self> {
+        // this is needed, so that users can call `.two_way_peekable()` without importing TwoWayIterator
+        TwoWayIterator::two_way_peekable(self)
+    }
+
     /// Advances the iterator backwards and returns the previous value.
     ///
     /// Runs in amortized O(1) time and worst-case O(log N) time.
     #[inline(always)]
     pub fn prev(&mut self) -> Option<&'a str> {
-        if !self.is_reversed {
-            self.prev_impl()
-        } else {
-            self.next_impl()
-        }
+        // this is needed, so that users can call `.prev()` without importing TwoWayIterator
+        TwoWayIterator::prev(self)
     }
 
     fn prev_impl(&mut self) -> Option<&'a str> {
@@ -1709,6 +1759,16 @@ impl<'a> Iterator for Chunks<'a> {
             self.next_impl()
         } else {
             self.prev_impl()
+        }
+    }
+}
+
+impl<'a> TwoWayIterator for Chunks<'a> {
+    fn prev(&mut self) -> Option<Self::Item> {
+        if !self.is_reversed {
+            self.prev_impl()
+        } else {
+            self.next_impl()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ mod tree;
 
 pub mod iter;
 pub mod str_utils;
+pub mod two_way_peekable;
 
 use std::ops::Bound;
 

--- a/src/two_way_peekable.rs
+++ b/src/two_way_peekable.rs
@@ -1,0 +1,213 @@
+pub trait TwoWayIterator: Iterator {
+    fn prev(&mut self) -> Option<Self::Item>;
+
+    fn two_way_peekable(self) -> TwoWayPeekable<Self>
+    where
+        Self: Sized,
+        Self::Item: Copy,
+    {
+        TwoWayPeekable {
+            itr: self,
+            peeked: Peeked::None,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Peeked<T> {
+    None,
+    Prev(Option<T>), // remember peeked value even if it was none
+    Next(Option<T>),
+}
+
+pub struct TwoWayPeekable<I>
+where
+    I: TwoWayIterator,
+    I::Item: Copy,
+{
+    itr: I,
+    peeked: Peeked<I::Item>,
+}
+
+impl<I> Iterator for TwoWayPeekable<I>
+where
+    I: TwoWayIterator,
+    I::Item: Copy,
+{
+    type Item = I::Item;
+
+    /// Advances the iterator forward and returns the next value.
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.peeked {
+            Peeked::None => self.itr.next(),
+            Peeked::Next(next) => {
+                self.peeked = Peeked::None;
+                next
+            }
+            Peeked::Prev(_) => {
+                self.peeked = Peeked::None;
+                self.itr.next(); // compensate for prev peeked one
+                self.itr.next()
+            }
+        }
+    }
+}
+
+impl<I> TwoWayIterator for TwoWayPeekable<I>
+where
+    I: TwoWayIterator,
+    I::Item: Copy,
+{
+    /// Advances the iterator backwards and returns the previous value.
+    #[inline]
+    fn prev(&mut self) -> Option<Self::Item> {
+        match self.peeked {
+            Peeked::None => self.itr.prev(),
+            Peeked::Prev(prev) => {
+                self.peeked = Peeked::None;
+                prev
+            }
+            Peeked::Next(_) => {
+                self.peeked = Peeked::None;
+                self.itr.prev(); // compensate for prev peeked one
+                self.itr.prev()
+            }
+        }
+    }
+}
+
+impl<I> TwoWayPeekable<I>
+where
+    I: TwoWayIterator,
+    I::Item: Copy,
+{
+    /// Return the next value witout advancing the iterator.
+    #[inline]
+    pub fn peek_next(&mut self) -> Option<I::Item> {
+        match self.peeked {
+            Peeked::Next(next) => next,
+            _ => {
+                if let Peeked::Prev(Some(_)) = self.peeked {
+                    // compensate for prev peeked one
+                    self.itr.next();
+                }
+
+                let next = self.itr.next();
+                self.peeked = Peeked::Next(next);
+                next
+            }
+        }
+    }
+
+    /// Return the previous value witout advancing the iterator.
+    #[inline]
+    pub fn peek_prev(&mut self) -> Option<I::Item> {
+        match self.peeked {
+            Peeked::Prev(prev) => prev,
+            _ => {
+                if let Peeked::Next(Some(_)) = self.peeked {
+                    // compensate for next peeked one
+                    self.itr.prev();
+                }
+
+                let prev = self.itr.prev();
+                self.peeked = Peeked::Prev(prev);
+                prev
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rope;
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn chars_01() {
+        let r = Rope::from_str("a");
+        let mut i = r.chars().two_way_peekable();
+
+        assert_eq!(None, i.prev());
+        assert_eq!(Some('a'), i.peek_next());
+        assert_eq!(Some('a'), i.next());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn chars_02() {
+        let r = Rope::from_str("a");
+        let mut i = r.chars().two_way_peekable();
+
+        assert_eq!(Some('a'), i.next());
+        assert_eq!(None, i.next());
+        assert_eq!(Some('a'), i.peek_prev());
+        assert_eq!(Some('a'), i.prev());
+        assert_eq!(None, i.peek_prev());
+        assert_eq!(Some('a'), i.peek_next());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn chars_03() {
+        let r = Rope::from_str("ab");
+        let mut i = r.chars().two_way_peekable();
+
+        assert_eq!(Some('a'), i.next());
+        assert_eq!(Some('b'), i.peek_next());
+        assert_eq!(Some('a'), i.peek_prev());
+        assert_eq!(Some('b'), i.next());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn chars_04() {
+        let r = Rope::from_str("ab");
+        let mut i = r.chars().two_way_peekable();
+
+        assert_eq!(Some('a'), i.next());
+        assert_eq!(Some('b'), i.next());
+        assert_eq!(None, i.peek_next());
+        assert_eq!(Some('b'), i.peek_prev());
+        assert_eq!(None, i.next());
+        assert_eq!(Some('b'), i.peek_prev());
+        assert_eq!(Some('b'), i.prev());
+        assert_eq!(Some('a'), i.prev());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn chars_reversed() {
+        let r = Rope::from_str("ab");
+        let mut i = r.chars().reversed().two_way_peekable();
+
+        assert_eq!(None, i.next());
+        assert_eq!(Some('a'), i.prev());
+        assert_eq!(Some('b'), i.peek_prev());
+        assert_eq!(Some('a'), i.peek_next());
+        assert_eq!(Some('b'), i.prev());
+        assert_eq!(None, i.prev());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn lines() {
+        let r = Rope::from_str(
+            "\
+Roses are red
+Violets are blue
+Ropes are brown
+or yellow? idk",
+        );
+        let mut i = r.lines().two_way_peekable();
+
+        assert_eq!(Some("Roses are red\n".into()), i.next());
+        assert_eq!(Some("Violets are blue\n".into()), i.next());
+        assert_eq!(Some("Ropes are brown\n".into()), i.next());
+        assert_eq!(Some("or yellow? idk".into()), i.peek_next());
+        assert_eq!(Some("Ropes are brown\n".into()), i.peek_prev());
+        assert_eq!(Some("or yellow? idk".into()), i.next());
+    }
+}


### PR DESCRIPTION
Closes #82.

I decided to make a struct `TwoWayPeekable` which will contain the iterator and the peeked value, similar to `std::iter::Peekable`. This allows to eliminate code duplication and this way the peeking-related overhead will affect only those who need to peek. As a downside, this approach increases the API surface area. It introduces a new trait `TwoWayIterator`, which probably should be a standard library feature.

I named the method that makes iterator peekable `.two_way_peekable()`, because `.peekable()` would conflict with `std::iter::Iterator::peekable`. Admittedly, `two_way_peekable` is not a very good name, so it probably should be changed, but I don't know to what. We _could_ just name it `peekable`, but that would be a breaking change, and would require a major version bump, so probably not worth it.