### PR TITLE
Add `line + column <-> char` indexes conversion helpers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,12 @@ pub enum Error {
     /// `Rope`/`RopeSlice` in lines, in that order.
     LineIndexOutOfBounds(usize, usize),
 
+    /// Indicates that the passed column index was out of line's bounds.
+    ///
+    /// Contains the index attempted and the actual length of the line
+    /// in characters, in that order.
+    ColumnIndexOutOfBounds(usize, usize),
+
     /// Indicates that the passed utf16 code-unit index was out of
     /// bounds.
     ///
@@ -318,6 +324,13 @@ impl std::fmt::Debug for Error {
                 write!(
                     f,
                     "Line index out of bounds: line index {}, Rope/RopeSlice line count {}",
+                    index, len
+                )
+            }
+            Error::ColumnIndexOutOfBounds(index, len) => {
+                write!(
+                    f,
+                    "Column index out of bounds: column index {}, line's length {}",
                     index, len
                 )
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ extern crate smallvec;
 extern crate str_indices;
 
 mod crlf;
+mod line_column;
 mod rope;
 mod rope_builder;
 mod slice;
@@ -181,6 +182,7 @@ pub mod str_utils;
 
 use std::ops::Bound;
 
+pub use crate::line_column::LineColumn;
 pub use crate::rope::Rope;
 pub use crate::rope_builder::RopeBuilder;
 pub use crate::slice::RopeSlice;

--- a/src/line_column.rs
+++ b/src/line_column.rs
@@ -1,0 +1,14 @@
+/// Zero-based line and column
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LineColumn {
+    /// Zero-based line number
+    pub line: usize,
+    /// Zero-based column number
+    pub column: usize,
+}
+
+impl From<(usize, usize)> for LineColumn {
+    fn from((line, column): (usize, usize)) -> Self {
+        Self { line, column }
+    }
+}


### PR DESCRIPTION
This is useful when implementing extension for vscode, because it uses line+column indexes instead of chars