### PR TITLE
Small Corrections and Rewording, Mostly README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ in terms of char indices, which prevents accidental creation of invalid
 UTF-8 data.
 
 Ropey also supports converting between scalar value indices and UTF-16 code unit
-indices, for interoperation with external APIs that may still use UTF-16.
+indices, for interoperability with external APIs that may still use UTF-16.
 
 ### Line-aware
 
@@ -140,7 +140,7 @@ unsafe code even better.
 ## Used by
 
 - [Helix](https://helix-editor.com/)
-- [rspack](https://github.com/web-infra-dev/rspack)
+- [rspack](https://www.rspack.dev/)
 - [postgres_lsp](https://github.com/supabase/postgres_lsp)
 - [oxc](https://github.com/web-infra-dev/oxc)
 - [zee](https://github.com/zee-editor/zee)
@@ -148,7 +148,7 @@ unsafe code even better.
 
 ## License
 
-Ropey is licensed under the MIT license (LICENSE.md or https://opensource.org/licenses/MIT)
+Ropey is licensed under the MIT license ([LICENSE.md](/LICENSE.md) or https://opensource.org/licenses/MIT)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a Rust UTF-8 text [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) designed for programs such as text editors, that can efficiently handle large amounts of text and memory-incoherent edits.
+Ropey is a Rust UTF-8 text [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) for programs such as text editors, that can efficiently handle large amounts of text and memory-incoherent edits.
 
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Ropey is designed to be the backing text buffer for programs like text editors, 
 
 On the other hand, Ropey is _not_ good at:
 
-- **Handling texts smaller than a few kilobytes.** Ropey will handle them fine, but 
+- **Handling texts smaller than a few kilobytes.** Ropey will handle them fine, but it
   allocates space in kilobyte chunks, which introduces unnecessary bloat if your text 
   is almost always small.
 - **Handling texts that are larger than available memory.** Ropey is an in-memory

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Ropey is designed to be the backing text buffer for programs like text editors, 
 On the other hand, Ropey is _not_ good at:
 
 - **Handling texts smaller than a few kilobytes.** Ropey will handle them fine, but it
-  allocates space in kilobyte chunks, which introduces unnecessary bloat if your text 
+  allocates space in kilobyte chunks, introducing unnecessary bloat if your text 
   is almost always small.
 - **Handling texts that are larger than available memory.** Ropey is an in-memory
   data structure.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a UTF-8 text rope for Rust, designed for programs like text editors, handling large
-texts and memory-incoherent edits efficiently.
+Ropey is a UTF-8 [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) text buffer for Rust, designed for programs like text editors, handling large armounts of texts and memory-incoherent edits efficiently.
 
 
 ## Example usage
+_See the [examples directory](examples/) for more examples._
 
 ```rust
 // Load a text file.
@@ -42,37 +42,35 @@ text.write_to(
 
 ## When should I use Ropey?
 
-Ropey is designed and built to be the backing text buffer for applications
-such as text editors, and its design trade-offs reflect that. Ropey is good
-at:
+Ropey is designed and built to be the backing text buffer for programs like text editors, and its design trade-offs reflect that. Ropey is good at:
 
-- Handling frequent edits to medium-to-large texts. Even on texts that are
+- **Handling frequent edits to medium-to-large texts.** Even on texts that are
   multiple gigabytes large, edits are measured in single-digit microseconds.
-- Handling Unicode correctly. It is impossible to create invalid UTF-8 through
+- **Handling Unicode correctly.** It is impossible to create invalid UTF-8 through
   Ropey, and all Unicode line endings are correctly tracked including CRLF.
-- Having flat, predictable performance characteristics. Ropey will never be
+- **Having flat, predictable performance characteristics.** Ropey will never be
   the source of hiccups or stutters in your software.
 
 On the other hand, Ropey is _not_ good at:
 
-- Handling texts smaller than a couple of kilobytes or so. That is to say,
-  Ropey will handle them fine, but Ropey allocates space in kilobyte chunks,
-  which introduces unnecessary bloat if your texts are almost always small.
-- Handling texts that are larger than available memory. Ropey is an in-memory
+- **Handling texts smaller than a few kilobytes.** Ropey will handle them fine, but 
+  allocates space in kilobyte chunks, which introduces unnecessary bloat if your text 
+  is almost always small.
+- **Handling texts that are larger than available memory.** Ropey is an in-memory
   data structure.
-- Getting the best performance for every possible use-case. Ropey puts work
-  into tracking both line endings and unicode scalar values, which is
+- **Getting the best performance for every possible use-case.** Ropey puts work
+  into tracking both line endings and Unicode scalar values, which is
   performance overhead you may not need depending on your use-case.
 
-Keep this in mind when considering Ropey for your project. Ropey is very good
-at what it does, but like all software it is designed with certain
-applications in mind.
+Keep this in mind when considering Ropey for your project. Ropey is great
+at what it does, but like all libraries, it is designed with specific
+use cases in mind.
 
 
 ## Features
 
 ### Strong Unicode support
-Ropey's atomic unit of text is
+Ropey's atomic units of text are
 [Unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value)
 (or [`char`](https://doc.rust-lang.org/std/primitive.char.html)s in Rust)
 encoded as UTF-8. All of Ropey's editing and slicing operations are done
@@ -107,8 +105,8 @@ implemented by client code with minimal overhead.
 
 Ropey is fast and minimizes memory usage:
 
-- On a recent mobile i7 Intel CPU, Ropey performed over 1.8 million small
-  incoherent insertions per second while building up a text roughly 100 MB
+- On a recent Intel i7 mobile CPU, Ropey performed over 1.8 million small
+  incoherent insertions per second while building up text roughly 100 MB
   large. Coherent insertions (i.e. all near the same place in the text) are
   even faster, doing the same task at over 3.3 million insertions per
   second.
@@ -137,6 +135,15 @@ If you find any unsoundness, _please_ file an issue! Also welcome are
 recommendations for how to remove any of the unsafe code without introducing
 significant space or performance regressions, or how to compartmentalize the
 unsafe code even better.
+
+
+## Used by
+
+- [Helix](https://helix-editor.com/)
+- [rspack](https://github.com/web-infra-dev/rspack)
+- [postgres_lsp](https://github.com/supabase/postgres_lsp)
+- [oxc](https://github.com/web-infra-dev/oxc)
+- [zee](https://github.com/zee-editor/zee)
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a utf8 text rope for Rust, designed to be the backing text-buffer for
-applications such as text editors.  Ropey is fast, robust, and can handle huge
-texts and memory-incoherent edits with ease.
+Ropey is a UTF-8 text rope for Rust, designed for programs like text editors, handling large
+texts and memory-incoherent edits efficiently.
 
 
-## Example Usage
+## Example usage
 
 ```rust
 // Load a text file.
@@ -41,31 +40,31 @@ text.write_to(
 )?;
 ```
 
-## When Should I Use Ropey?
+## When should I use Ropey?
 
 Ropey is designed and built to be the backing text buffer for applications
-such as text editors, and its design trade-offs reflect that.  Ropey is good
+such as text editors, and its design trade-offs reflect that. Ropey is good
 at:
 
-- Handling frequent edits to medium-to-large texts.  Even on texts that are
+- Handling frequent edits to medium-to-large texts. Even on texts that are
   multiple gigabytes large, edits are measured in single-digit microseconds.
-- Handling Unicode correctly.  It is impossible to create invalid utf8 through
+- Handling Unicode correctly. It is impossible to create invalid UTF-8 through
   Ropey, and all Unicode line endings are correctly tracked including CRLF.
-- Having flat, predictable performance characteristics.  Ropey will never be
+- Having flat, predictable performance characteristics. Ropey will never be
   the source of hiccups or stutters in your software.
 
 On the other hand, Ropey is _not_ good at:
 
-- Handling texts smaller than a couple of kilobytes or so.  That is to say,
+- Handling texts smaller than a couple of kilobytes or so. That is to say,
   Ropey will handle them fine, but Ropey allocates space in kilobyte chunks,
   which introduces unnecessary bloat if your texts are almost always small.
-- Handling texts that are larger than available memory.  Ropey is an in-memory
+- Handling texts that are larger than available memory. Ropey is an in-memory
   data structure.
-- Getting the best performance for every possible use-case.  Ropey puts work
+- Getting the best performance for every possible use-case. Ropey puts work
   into tracking both line endings and unicode scalar values, which is
   performance overhead you may not need depending on your use-case.
 
-Keep this in mind when selecting Ropey for your project.  Ropey is very good
+Keep this in mind when considering Ropey for your project. Ropey is very good
 at what it does, but like all software it is designed with certain
 applications in mind.
 
@@ -76,12 +75,12 @@ applications in mind.
 Ropey's atomic unit of text is
 [Unicode scalar values](https://www.unicode.org/glossary/#unicode_scalar_value)
 (or [`char`](https://doc.rust-lang.org/std/primitive.char.html)s in Rust)
-encoded as utf8.  All of Ropey's editing and slicing operations are done
+encoded as UTF-8. All of Ropey's editing and slicing operations are done
 in terms of char indices, which prevents accidental creation of invalid
-utf8 data.
+UTF-8 data.
 
-Ropey also supports converting between scalar value indices and utf16 code unit
-indices, for interoperation with external APIs that may still use utf16.
+Ropey also supports converting between scalar value indices and UTF-16 code unit
+indices, for interoperation with external APIs that may still use UTF-16.
 
 ### Line-aware
 
@@ -89,7 +88,7 @@ Ropey knows about line breaks, allowing you to index into and iterate over
 lines of text.
 
 The line breaks Ropey recognizes are also configurable at build time via
-feature flags.  See Ropey's documentation for details.
+feature flags. See Ropey's documentation for details.
 
 ### Rope slices
 
@@ -110,14 +109,14 @@ Ropey is fast and minimizes memory usage:
 
 - On a recent mobile i7 Intel CPU, Ropey performed over 1.8 million small
   incoherent insertions per second while building up a text roughly 100 MB
-  large.  Coherent insertions (i.e. all near the same place in the text) are
+  large. Coherent insertions (i.e. all near the same place in the text) are
   even faster, doing the same task at over 3.3 million insertions per
   second.
-- Freshly loading a file from disk only incurs about 10% memory overhead.  For
+- Freshly loading a file from disk only incurs about 10% memory overhead. For
   example, a 100 MB text file will occupy about 110 MB of memory when loaded
   by Ropey.
-- Cloning ropes is _extremely_ cheap.  Rope clones share data, so an initial
-  clone only takes 8 bytes of memory.  After that, memory usage will grow
+- Cloning ropes is _extremely_ cheap. Rope clones share data, so an initial
+  clone only takes 8 bytes of memory. After that, memory usage will grow
   incrementally as the clones diverge due to edits.
 
 ### Thread safe
@@ -129,12 +128,12 @@ Clones can be sent to other threads for both reading and writing.
 ## Unsafe code
 
 Ropey uses unsafe code to help achieve some of its space and performance
-characteristics.  Although effort has been put into keeping the unsafe code
-compartmentalized and making it correct, please be cautious about using Ropey
+characteristics. Although effort has been put into keeping the unsafe code
+compartmentalized and correct, please be cautious about using Ropey
 in software that may face adversarial conditions.
 
-Auditing, fuzzing, etc. of the unsafe code in Ropey is extremely welcome.
-If you find any unsoundness, _please_ file an issue!  Also welcome are
+Auditing, fuzzing, etc., of the unsafe code in Ropey is extremely welcome.
+If you find any unsoundness, _please_ file an issue! Also welcome are
 recommendations for how to remove any of the unsafe code without introducing
 significant space or performance regressions, or how to compartmentalize the
 unsafe code even better.
@@ -142,12 +141,12 @@ unsafe code even better.
 
 ## License
 
-Ropey is licensed under the MIT license (LICENSE.md or http://opensource.org/licenses/MIT)
+Ropey is licensed under the MIT license (LICENSE.md or https://opensource.org/licenses/MIT)
 
 
 ## Contributing
 
-Contributions are absolutely welcome!  However, please open an issue or email
+Contributions are absolutely welcome! However, please open an issue or email
 me to discuss larger changes, to avoid doing a lot of work that may get
 rejected.
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ unsafe code even better.
 ## Used by
 
 - [Helix](https://helix-editor.com/)
-- [rspack](https://www.rspack.dev/)
+- [Rspack](https://www.rspack.dev/)
 - [postgres_lsp](https://github.com/supabase/postgres_lsp)
-- [oxc](https://github.com/web-infra-dev/oxc)
+- [Oxc](https://github.com/web-infra-dev/oxc)
 - [zee](https://github.com/zee-editor/zee)
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a Rust UTF-8 [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) text buffer, designed for programs like text editors, handling large armounts of texts and memory-incoherent edits efficiently.
+Ropey is a Rust UTF-8 text [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) designed for programs such as text editors, that can efficiently handle large amounts of text and memory-incoherent edits.
 
 
 ## Example usage
@@ -42,7 +42,7 @@ text.write_to(
 
 ## When should I use Ropey?
 
-Ropey is designed and built to be the backing text buffer for programs like text editors, and its design trade-offs reflect that. Ropey is good at:
+Ropey is designed to be the backing text buffer for programs like text editors, and its design trade-offs reflect that. Ropey is good at:
 
 - **Handling frequent edits to medium-to-large texts.** Even on texts that are
   multiple gigabytes large, edits are measured in single-digit microseconds.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a Rust UTF-8 text [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) for programs such as text editors, that can efficiently handle large amounts of text and memory-incoherent edits.
+Ropey is a Rust UTF-8 text [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) library made to be used as the text buffer in programs such as text editors. It can efficiently handle large amounts of text and memory-incoherent edits.
 
 
 ## Example usage
@@ -157,7 +157,7 @@ Contributions are absolutely welcome! However, please open an issue or email
 me to discuss larger changes, to avoid doing a lot of work that may get
 rejected.
 
-An overview of Ropey's design can be found [here](https://github.com/cessen/ropey/blob/master/design/design.md).
+An overview of Ropey's design can be found [here](/design/design.md).
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in Ropey by you will be licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Release][crates-io-badge]][crates-io-url]
 [![Documentation][docs-rs-img]][docs-rs-url]
 
-Ropey is a UTF-8 [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) text buffer for Rust, designed for programs like text editors, handling large armounts of texts and memory-incoherent edits efficiently.
+Ropey is a Rust UTF-8 [rope](https://en.wikipedia.org/wiki/Rope_(data_structure)) text buffer, designed for programs like text editors, handling large armounts of texts and memory-incoherent edits efficiently.
 
 
 ## Example usage

--- a/src/crlf.rs
+++ b/src/crlf.rs
@@ -1,6 +1,6 @@
 /// Returns whether the given byte index in `text` is a valid
 /// splitting point.  Valid splitting point in this case means
-/// that it _is_ a utf8 code point boundary and _is not_ the
+/// that it _is_ a UTF-8 code point boundary and _is not_ the
 /// middle of a CRLF pair.
 #[inline]
 pub fn is_break(byte_idx: usize, text: &[u8]) -> bool {
@@ -15,7 +15,7 @@ pub fn is_break(byte_idx: usize, text: &[u8]) -> bool {
 
 /// Returns whether the seam between `left` and `right` is a valid
 /// splitting point.  Valid splitting point in this case means
-/// that it _is_ a utf8 code point boundary and _is not_ the middle
+/// that it _is_ a UTF-8 code point boundary and _is not_ the middle
 /// of a CRLF pair.
 #[inline]
 pub fn seam_is_break(left: &[u8], right: &[u8]) -> bool {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1250,15 +1250,15 @@ impl ExactSizeIterator for Lines<'_> {}
 
 /// An iterator over a `Rope`'s contiguous `str` chunks.
 ///
-/// Internally, each `Rope` stores text as a segemented collection of utf8
+/// Internally, each `Rope` stores text as a segemented collection of UTF-8
 /// strings. This iterator iterates over those segments, returning a
 /// `&str` slice for each one.  It is useful for situations such as:
 ///
-/// - Writing a rope's utf8 text data to disk (but see
+/// - Writing a rope's UTF-8 text data to disk (but see
 ///   [`write_to()`](crate::rope::Rope::write_to) for a convenience function that does this
 ///   for casual use-cases).
 /// - Streaming a rope's text data somewhere.
-/// - Saving a rope to a non-utf8 encoding, doing the encoding conversion
+/// - Saving a rope to a non-UTF-8 encoding, doing the encoding conversion
 ///   incrementally as you go.
 /// - Writing custom iterators over a rope's text data.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-//! Ropey is a utf8 text rope for Rust.  It is fast, robust, and can handle
+//! Ropey is a UTF-8 text rope for Rust. It is fast, robust, and can handle
 //! huge texts and memory-incoherent edits with ease.
 //!
 //! Ropey's atomic unit of text is Unicode scalar values (or `char`s in Rust)
-//! encoded as utf8.  All of Ropey's editing and slicing operations are done
+//! encoded as UTF-8. All of Ropey's editing and slicing operations are done
 //! in terms of char indices, which prevents accidental creation of invalid
-//! utf8 data.
+//! UTF-8 data.
 //!
 //! The library is made up of four main components:
 //!
@@ -19,7 +19,7 @@
 //! # A Basic Example
 //!
 //! Let's say we want to open up a text file, replace the 516th line (the
-//! writing was terrible!), and save it back to disk.  It's contrived, but will
+//! writing was terrible!), and save it back to disk. It's contrived, but will
 //! give a good sampling of the APIs and how they work together.
 //!
 //! ```no_run
@@ -63,16 +63,16 @@
 //! ```
 //!
 //! More examples can be found in the `examples` directory of the git
-//! repository.  Many of those examples demonstrate doing non-trivial things
+//! repository. Many of those examples demonstrate doing non-trivial things
 //! with Ropey such as grapheme handling, search-and-replace, and streaming
-//! loading of non-utf8 text files.
+//! loading of non-UTF-8 text files.
 //!
 //!
-//! # Low-level APIs
+//! # Low-Level APIs
 //!
 //! Ropey also provides access to some of its low-level APIs, enabling client
 //! code to efficiently work with a `Rope`'s data and implement new
-//! functionality.  The most important of those API's are:
+//! functionality. The most important of those APIs are:
 //!
 //! - The [`chunk_at_*()`](Rope::chunk_at_byte)
 //!   chunk-fetching methods of `Rope` and `RopeSlice`.
@@ -80,10 +80,10 @@
 //! - The functions in [`str_utils`] for operating on
 //!   `&str` slices.
 //!
-//! Internally, each `Rope` stores text as a segemented collection of utf8
-//! strings.  The chunk-fetching methods and `Chunks` iterator provide direct
+//! Internally, each `Rope` stores text as a segemented collection of UTF-8
+//! strings. The chunk-fetching methods and `Chunks` iterator provide direct
 //! access to those strings (or "chunks") as `&str` slices, allowing client
-//! code to work directly with the underlying utf8 data.
+//! code to work directly with the underlying UTF-8 data.
 //!
 //! The chunk-fetching methods and `str_utils` functions are the basic
 //! building blocks that Ropey itself uses to build much of its functionality.
@@ -114,16 +114,16 @@
 //! Some of Ropey's APIs use the concept of line breaks or lines of text.
 //!
 //! Ropey considers the start of the rope and positions immediately
-//! _after_ line breaks to be the start of new lines.  And it treats
+//! _after_ line breaks to be the start of new lines. And it treats
 //! line breaks as being a part of the lines they mark the end of.
 //!
-//! For example, the rope `"Hello"` has a single line: `"Hello"`.  The
-//! rope `"Hello\nworld"` has two lines: `"Hello\n"` and `"world"`.  And
+//! For example, the rope `"Hello"` has a single line: `"Hello"`. The
+//! rope `"Hello\nworld"` has two lines: `"Hello\n"` and `"world"`. And
 //! the rope `"Hello\nworld\n"` has three lines: `"Hello\n"`,
 //! `"world\n"`, and `""`.
 //!
 //! Ropey can be configured at build time via feature flags to recognize
-//! different line breaks.  Ropey always recognizes:
+//! different line breaks. Ropey always recognizes:
 //!
 //! - `U+000A`          &mdash; LF (Line Feed)
 //! - `U+000D` `U+000A` &mdash; CRLF (Carriage Return + Line Feed)
@@ -147,7 +147,7 @@
 //! `cr_lines`.)
 //!
 //! CRLF pairs are always treated as a single line break, and are never split
-//! across chunks.  Note, however, that slicing can still split them.
+//! across chunks. Note, however, that slicing can still split them.
 //!
 //!
 //! # A Note About SIMD Acceleration
@@ -156,8 +156,8 @@
 //! explicit SIMD on supported platforms to improve performance.
 //!
 //! There is a bit of a footgun here: if you disable default features to
-//! configure line break behavior (as per the section above) then SIMD
-//! will also get disabled, and performance will suffer.  So be careful
+//! configure line break behavior (as per the section above), then SIMD
+//! will also get disabled, and performance will suffer. So be careful
 //! to explicitly re-enable the `simd` feature flag (if desired) when
 //! doing that.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,11 +213,11 @@ pub enum Error {
     /// `Rope`/`RopeSlice` in lines, in that order.
     LineIndexOutOfBounds(usize, usize),
 
-    /// Indicates that the passed utf16 code-unit index was out of
+    /// Indicates that the passed UTF-16 code-unit index was out of
     /// bounds.
     ///
     /// Contains the index attempted and the actual length of the
-    /// `Rope`/`RopeSlice` in utf16 code units, in that order.
+    /// `Rope`/`RopeSlice` in UTF-16 code units, in that order.
     Utf16IndexOutOfBounds(usize, usize),
 
     /// Indicates that the passed byte index was not a char boundary.
@@ -320,7 +320,7 @@ impl std::fmt::Debug for Error {
                 )
             }
             Error::Utf16IndexOutOfBounds(index, len) => {
-                write!(f, "Utf16 code-unit index out of bounds: utf16 index {}, Rope/RopeSlice utf16 length {}", index, len)
+                write!(f, "UTF-16 code-unit index out of bounds: UTF-16 index {}, Rope/RopeSlice UTF-16 length {}", index, len)
             }
             Error::ByteIndexNotCharBoundary(index) => {
                 write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //! loading of non-UTF-8 text files.
 //!
 //!
-//! # Low-Level APIs
+//! # Low-level APIs
 //!
 //! Ropey also provides access to some of its low-level APIs, enabling client
 //! code to efficiently work with a `Rope`'s data and implement new

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -14,7 +14,7 @@ use crate::str_utils::{
 use crate::tree::{Count, Node, NodeChildren, TextInfo, MAX_BYTES, MIN_BYTES};
 use crate::{end_bound_to_num, start_bound_to_num, Error, Result};
 
-/// A utf8 text rope.
+/// A UTF-8 text rope.
 ///
 /// The time complexity of nearly all edit and query operations on `Rope` are
 /// worst-case `O(log N)` in the length of the rope.  `Rope` is designed to
@@ -120,7 +120,7 @@ impl Rope {
     ///
     /// - If the reader returns an error, `from_reader` stops and returns
     ///   that error.
-    /// - If non-utf8 data is encountered, an IO error with kind
+    /// - If non-UTF-8 data is encountered, an IO error with kind
     ///   `InvalidData` is returned.
     ///
     /// Note: some data from the reader is likely consumed even if there is
@@ -248,11 +248,11 @@ impl Rope {
         self.root.line_break_count() + 1
     }
 
-    /// Total number of utf16 code units that would be in `Rope` if it were
-    /// encoded as utf16.
+    /// Total number of UTF-16 code units that would be in `Rope` if it were
+    /// encoded as UTF-16.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16. This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
@@ -690,10 +690,10 @@ impl Rope {
         self.try_char_to_line(char_idx).unwrap()
     }
 
-    /// Returns the utf16 code unit index of the given char.
+    /// Returns the UTF-16 code unit index of the given char.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16.  This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
@@ -707,14 +707,14 @@ impl Rope {
         self.try_char_to_utf16_cu(char_idx).unwrap()
     }
 
-    /// Returns the char index of the given utf16 code unit.
+    /// Returns the char index of the given UTF-16 code unit.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16.  This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
-    /// Note: if the utf16 code unit is in the middle of a char, returns the
+    /// Note: if the UTF-16 code unit is in the middle of a char, returns the
     /// index of the char that it belongs to.
     ///
     /// Runs in O(log N) time.

--- a/src/rope_builder.rs
+++ b/src/rope_builder.rs
@@ -15,7 +15,7 @@ use crate::tree::{Node, NodeChildren, NodeText, MAX_BYTES, MAX_CHILDREN, MIN_BYT
 ///   memory (but see [`from_reader()`](Rope::from_reader) for a convenience
 ///   function that does this for casual use-cases).
 /// - ...streaming data sources.
-/// - ...non-utf8 text data, doing the encoding conversion incrementally
+/// - ...non-UTF-8 text data, doing the encoding conversion incrementally
 ///   as you go.
 ///
 /// Unlike repeatedly calling `Rope::insert()` on the end of a rope,
@@ -65,7 +65,7 @@ impl RopeBuilder {
     /// `Rope`.  The passed text chunk can be as large or small as
     /// desired, but larger chunks are more efficient.
     ///
-    /// `chunk` must be valid utf8 text.
+    /// `chunk` must be valid UTF-8 text.
     pub fn append(&mut self, chunk: &str) {
         self.append_internal(chunk, false);
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -274,11 +274,11 @@ impl<'a> RopeSlice<'a> {
         }
     }
 
-    /// Total number of utf16 code units that would be in the `RopeSlice` if
-    /// it were encoded as utf16.
+    /// Total number of UTF-16 code units that would be in the `RopeSlice` if
+    /// it were encoded as UTF-16.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16.  This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
@@ -379,10 +379,10 @@ impl<'a> RopeSlice<'a> {
         self.try_char_to_line(char_idx).unwrap()
     }
 
-    /// Returns the utf16 code unit index of the given char.
+    /// Returns the UTF-16 code unit index of the given char.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16.  This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
@@ -396,14 +396,14 @@ impl<'a> RopeSlice<'a> {
         self.try_char_to_utf16_cu(char_idx).unwrap()
     }
 
-    /// Returns the char index of the given utf16 code unit.
+    /// Returns the char index of the given UTF-16 code unit.
     ///
-    /// Ropey stores text internally as utf8, but sometimes it is necessary
-    /// to interact with external APIs that still use utf16.  This function is
+    /// Ropey stores text internally as UTF-8, but sometimes it is necessary
+    /// to interact with external APIs that still use UTF-16.  This function is
     /// primarily intended for such situations, and is otherwise not very
     /// useful.
     ///
-    /// Note: if the utf16 code unit is in the middle of a char, returns the
+    /// Note: if the UTF-16 code unit is in the middle of a char, returns the
     /// index of the char that it belongs to.
     ///
     /// Runs in O(log N) time.

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -1,4 +1,4 @@
-//! Utility functions for utf8 string slices.
+//! Utility functions for UTF-8 string slices.
 //!
 //! This module provides various utility functions that operate on string
 //! slices in ways compatible with Ropey.  They may be useful when building

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -501,7 +501,7 @@ impl Node {
         }
     }
 
-    /// Returns the chunk that contains the given utf16 code unit, and the
+    /// Returns the chunk that contains the given UTF-16 code unit, and the
     /// TextInfo corresponding to the start of the chunk.
     pub fn get_chunk_at_utf16_code_unit(&self, utf16_idx: usize) -> (&str, TextInfo) {
         let mut node = self;

--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -352,7 +352,7 @@ impl NodeChildren {
     }
 
     /// Returns the child index and left-side-accumulated text info of the
-    /// child that contains the given utf16 code unit offset.
+    /// child that contains the given UTF-16 code unit offset.
     ///
     /// One-past-the end is valid, and will return the last child.
     pub fn search_utf16_code_unit_idx(&self, utf16_idx: usize) -> (usize, TextInfo) {


### PR DESCRIPTION
Changes made in README.md:

- Replaced all instances of utf8 or utf16 with UTF-8 and UTF-16
- Added link to [this Wikipedia page](https://en.wikipedia.org/wiki/Rope_(data_structure)) under first header "Ropey" (also reworded this part)
- Added link to examples directory above the "Example Usage" code block
- Bolded first sentences of each bullet point under "When Should I use Ropey?"
- Changed capitalization of each header to sentence case
- Made LICENSE.md under the "License" header a link.
- Added "Used By" section that contains 5 popular projects using Ropey
- Removed double spaces
-  Small rewording/grammar/capitalization in a few places possibly

Changes in code:
-  Replaced all instances of utf8 or utf16 with UTF-8 and UTF-16 in documentation


Read over the README.md carefully and change anything you don't like, such as the wording used or the projects shown under the "Used By" header. Thanks for this library, I'll be using it in a text editor I'm making soon. Also, does this crate need to be updated on crates.io?