### PR TITLE
[tests] Run search_char_idx_02 and search_line_break_idx_04 only in debug mode

### DIFF
--- a/src/tree/node_children.rs
+++ b/src/tree/node_children.rs
@@ -785,6 +785,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(debug_assertions)]
     fn search_char_idx_02() {
         let mut children = NodeChildren::new();
         children.push((
@@ -997,6 +998,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(debug_assertions)]
     fn search_line_break_idx_04() {
         let mut children = NodeChildren::new();
         children.push((


### PR DESCRIPTION
Both tests only panic in debug mode because debug_assert is used In release mode 'debug_assert' evaluates to a NOOP and the tests don't panic