### PR TITLE
accelerate line iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["/design/*", "/benches/*.txt", "/fuzz/**", "/.github/*"]
 
 [features]
 default = ["unicode_lines", "simd"]
+memchr = ["dep:memchr"]
 cr_lines = [] # Enable recognizing carriage returns as line breaks.
 unicode_lines = ["cr_lines"] # Enable recognizing all Unicode line breaks.
 simd = ["str_indices/simd"]
@@ -23,6 +24,7 @@ simd = ["str_indices/simd"]
 small_chunks = []
 
 [dependencies]
+memchr = { version = "2.7.2", optional = true}
 smallvec = "1.0.0"
 str_indices = { version = "0.4", default-features = false }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -70,7 +70,7 @@ use std::sync::Arc;
 use crate::slice::{RSEnum, RopeSlice};
 use crate::str_utils::{
     byte_to_line_idx, char_to_byte_idx, count_chars, count_utf16_surrogates, ends_with_line_break,
-    last_line_start_byte_idx, line_to_byte_idx, trim_line_break,
+    last_line_start_byte_idx, line_to_byte_idx, next_line_byte_idx, trim_line_break,
 };
 use crate::tree::{Count, Node, TextInfo};
 
@@ -1021,7 +1021,7 @@ impl<'a> Lines<'a> {
                 *line_idx += 1;
 
                 let head = &text[*leaf_byte_idx as usize..];
-                let mut line_len = line_to_byte_idx(head, 1);
+                let mut line_len = next_line_byte_idx(head);
 
                 // Check if the iterators needs to advance to the next chunk.
                 // During this check the number of newline (0 or 1) is yielded
@@ -1125,7 +1125,7 @@ impl<'a> Lines<'a> {
                         // This chunk contains a line break so it will contain the start of our line.
                         *text = node.children().nodes()[child_i].leaf_text();
                         // Find the end of the line within the chunk.
-                        let mut line_end = line_to_byte_idx(text, 1);
+                        let mut line_end = next_line_byte_idx(text);
                         // Check if the iterator was exhausted.
                         let ends_with_newline = if line_end >= available_bytes {
                             // Handle terminating lines without a line break properly.
@@ -1202,7 +1202,7 @@ impl<'a> Lines<'a> {
                 }
 
                 let start_idx = *byte_idx;
-                let end_idx = line_to_byte_idx(&text[start_idx..], 1) + start_idx;
+                let end_idx = next_line_byte_idx(&text[start_idx..]) + start_idx;
                 *byte_idx = end_idx;
                 *line_idx += 1;
 


### PR DESCRIPTION
ropeys line iterator doesn't do so well compared to other ropes and I always wondered why. My recent work on a streaming regex engine made clear to me why: The string search routines we use for finding lines are not well optimized. 

There are a couple of reasons I found (there may ben more):

* The reveres search did not use any simd at all
* The forward search does use simd (line_to_byte_idx) but these functions from `str_indices` are more optimized for counting/larger counts and don't do quite as well in the latency department (when line_idx=1)
* ropey support unicode line breaks (just turning those off makes a huge difference)

I optimized the str utilities used by the line iterator to adress the first two and somewhat the last point (nothing else uses these so nothing else is affected). memchr can be used to accelerate both forward and reverse searches. This was sadly not possible for the unicode lines case because `memchr` can only search for a set of up to three bytes. The aoh-corasic crate contains vectorized implementations that would allow accelerating these cases, but I didn't want to pull that in.

Some data, run a benchmark with:
* `cargo bench _lines --no-default-features --features "simd"` on the current master branch
* `cargo bench _lines --no-default-features --features "simd,memchr"` on this branch


Results:
```
iter_prev_lines/lines   time:   [34.199 ns 34.259 ns 34.320 ns] (was 51.73ns)
                        change: [-33.702% -33.533% -33.322%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
iter_prev_lines/lines_tiny
                        time:   [21.990 ns 22.012 ns 22.036 ns] (was 37.55ns)
                        change: [-41.540% -41.456% -41.369%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

iter_next_lines/lines   time:   [34.450 ns 34.552 ns 34.645 ns] (was 39.25ns)
                        change: [-13.055% -12.513% -12.145%] (p = 0.00 < 0.05)
                        Performance has improved.
iter_next_lines/lines_tiny
                        time:   [29.280 ns 29.383 ns 29.538 ns] (was 35.79ns)
                        change: [-17.247% -16.909% -16.571%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
```

`memchr` is behind a feature flag because it feels unfortunate to have a dependency not used by the default feature flag. Sadly you can't make a feature flag turn off a dependency so this hack will have to do. I think unicode line endings are one of things that are pedantically correct, but I suspect the majority of users will turn off and benefit from these optimizations.
