### PR TITLE
fix: add track_caller attr on panicking methods

### DIFF
--- a/src/rope.rs
+++ b/src/rope.rs
@@ -342,7 +342,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn insert(&mut self, char_idx: usize, text: &str) {
-        self.try_insert(char_idx, text).unwrap()
+        self.try_insert(char_idx, text)
+            .expect("index out of bounds")
     }
 
     /// Inserts a single char `ch` at char index `char_idx`.
@@ -355,7 +356,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn insert_char(&mut self, char_idx: usize, ch: char) {
-        self.try_insert_char(char_idx, ch).unwrap()
+        self.try_insert_char(char_idx, ch)
+            .expect("index out of bounds")
     }
 
     /// Private internal-only method that does a single insertion of
@@ -545,7 +547,7 @@ impl Rope {
     where
         R: RangeBounds<usize>,
     {
-        self.try_remove(char_range).unwrap()
+        self.try_remove(char_range).expect("index out of bounds")
     }
 
     /// Splits the `Rope` at `char_idx`, returning the right part of
@@ -558,7 +560,7 @@ impl Rope {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[track_caller]
     pub fn split_off(&mut self, char_idx: usize) -> Self {
-        self.try_split_off(char_idx).unwrap()
+        self.try_split_off(char_idx).expect("index out of bounds")
     }
 
     /// Appends a `Rope` to the end of this one, consuming the other `Rope`.
@@ -636,7 +638,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn byte_to_char(&self, byte_idx: usize) -> usize {
-        self.try_byte_to_char(byte_idx).unwrap()
+        self.try_byte_to_char(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the line index of the given byte.
@@ -656,7 +659,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn byte_to_line(&self, byte_idx: usize) -> usize {
-        self.try_byte_to_line(byte_idx).unwrap()
+        self.try_byte_to_line(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the byte index of the given char.
@@ -674,7 +678,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn char_to_byte(&self, char_idx: usize) -> usize {
-        self.try_char_to_byte(char_idx).unwrap()
+        self.try_char_to_byte(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the line index of the given char.
@@ -694,7 +699,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn char_to_line(&self, char_idx: usize) -> usize {
-        self.try_char_to_line(char_idx).unwrap()
+        self.try_char_to_line(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the utf16 code unit index of the given char.
@@ -712,7 +718,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn char_to_utf16_cu(&self, char_idx: usize) -> usize {
-        self.try_char_to_utf16_cu(char_idx).unwrap()
+        self.try_char_to_utf16_cu(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the char index of the given utf16 code unit.
@@ -734,7 +741,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn utf16_cu_to_char(&self, utf16_cu_idx: usize) -> usize {
-        self.try_utf16_cu_to_char(utf16_cu_idx).unwrap()
+        self.try_utf16_cu_to_char(utf16_cu_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the byte index of the start of the given line.
@@ -753,7 +761,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn line_to_byte(&self, line_idx: usize) -> usize {
-        self.try_line_to_byte(line_idx).unwrap()
+        self.try_line_to_byte(line_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the char index of the start of the given line.
@@ -772,7 +781,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn line_to_char(&self, line_idx: usize) -> usize {
-        self.try_line_to_char(line_idx).unwrap()
+        self.try_line_to_char(line_idx)
+            .expect("index out of bounds")
     }
 
     //-----------------------------------------------------------------------
@@ -788,16 +798,7 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn byte(&self, byte_idx: usize) -> u8 {
-        // Bounds check
-        if let Some(out) = self.get_byte(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: byte index {}, Rope byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_byte(byte_idx).expect("index out of bounds")
     }
 
     /// Returns the char at `char_idx`.
@@ -810,15 +811,7 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn char(&self, char_idx: usize) -> char {
-        if let Some(out) = self.get_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: char index {}, Rope char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_char(char_idx).expect("index out of bounds")
     }
 
     /// Returns the line at `line_idx`.
@@ -833,15 +826,7 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn line(&self, line_idx: usize) -> RopeSlice {
-        if let Some(out) = self.get_line(line_idx) {
-            out
-        } else {
-            let len_lines = self.len_lines();
-            panic!(
-                "Attempt to index past end of Rope: line index {}, Rope line length {}",
-                line_idx, len_lines
-            );
-        }
+        self.get_line(line_idx).expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given byte index.
@@ -863,16 +848,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn chunk_at_byte(&self, byte_idx: usize) -> (&str, usize, usize, usize) {
-        // Bounds check
-        if let Some(out) = self.get_chunk_at_byte(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: byte index {}, Rope byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_chunk_at_byte(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given char index.
@@ -894,15 +871,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn chunk_at_char(&self, char_idx: usize) -> (&str, usize, usize, usize) {
-        if let Some(out) = self.get_chunk_at_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: char index {}, Rope char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chunk_at_char(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given line break.
@@ -927,15 +897,8 @@ impl Rope {
     #[inline]
     #[track_caller]
     pub fn chunk_at_line_break(&self, line_break_idx: usize) -> (&str, usize, usize, usize) {
-        if let Some(out) = self.get_chunk_at_line_break(line_break_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: line break index {}, max index {}",
-                line_break_idx,
-                self.len_lines()
-            );
-        }
+        self.get_chunk_at_line_break(line_break_idx)
+            .expect("index out of bounds")
     }
 
     //-----------------------------------------------------------------------
@@ -967,7 +930,7 @@ impl Rope {
     where
         R: RangeBounds<usize>,
     {
-        self.get_slice(char_range).unwrap()
+        self.get_slice(char_range).expect("index out of bounds")
     }
 
     /// Gets and immutable slice of the `Rope`, using byte indices.
@@ -987,10 +950,8 @@ impl Rope {
     where
         R: RangeBounds<usize>,
     {
-        match self.get_byte_slice_impl(byte_range) {
-            Ok(s) => return s,
-            Err(e) => panic!("byte_slice(): {}", e),
-        }
+        self.get_byte_slice_impl(byte_range)
+            .expect("index out of bounds or unaligned with char boudaries")
     }
 
     //-----------------------------------------------------------------------
@@ -1017,15 +978,7 @@ impl Rope {
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
     pub fn bytes_at(&self, byte_idx: usize) -> Bytes {
-        if let Some(out) = self.get_bytes_at(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: byte index {}, Rope byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_bytes_at(byte_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the chars of the `Rope`.
@@ -1049,15 +1002,7 @@ impl Rope {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
     pub fn chars_at(&self, char_idx: usize) -> Chars {
-        if let Some(out) = self.get_chars_at(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: char index {}, Rope char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chars_at(char_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the lines of the `Rope`.
@@ -1081,15 +1026,7 @@ impl Rope {
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
     pub fn lines_at(&self, line_idx: usize) -> Lines {
-        if let Some(out) = self.get_lines_at(line_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: line index {}, Rope line length {}",
-                line_idx,
-                self.len_lines()
-            );
-        }
+        self.get_lines_at(line_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `Rope`.
@@ -1119,15 +1056,8 @@ impl Rope {
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
     pub fn chunks_at_byte(&self, byte_idx: usize) -> (Chunks, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_byte(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: byte index {}, Rope byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_chunks_at_byte(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `Rope`, with the
@@ -1149,15 +1079,8 @@ impl Rope {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
     pub fn chunks_at_char(&self, char_idx: usize) -> (Chunks, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: char index {}, Rope char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chunks_at_char(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `Rope`, with the
@@ -1183,15 +1106,8 @@ impl Rope {
     /// Panics if `line_break_idx` is out of bounds (i.e. `line_break_idx > len_lines()`).
     #[inline]
     pub fn chunks_at_line_break(&self, line_break_idx: usize) -> (Chunks, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_line_break(line_break_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: line break index {}, max index {}",
-                line_break_idx,
-                self.len_lines()
-            );
-        }
+        self.get_chunks_at_line_break(line_break_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns true if this rope and `other` point to precisely the same

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -340,8 +340,8 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn insert(&mut self, char_idx: usize, text: &str) {
-        // Bounds check
         self.try_insert(char_idx, text).unwrap()
     }
 
@@ -353,6 +353,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn insert_char(&mut self, char_idx: usize, ch: char) {
         self.try_insert_char(char_idx, ch).unwrap()
     }
@@ -539,6 +540,7 @@ impl Rope {
     ///
     /// Panics if the start of the range is greater than the end, or if the
     /// end is out of bounds (i.e. `end > len_chars()`).
+    #[track_caller]
     pub fn remove<R>(&mut self, char_range: R)
     where
         R: RangeBounds<usize>,
@@ -554,6 +556,7 @@ impl Rope {
     /// # Panics
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
+    #[track_caller]
     pub fn split_off(&mut self, char_idx: usize) -> Self {
         self.try_split_off(char_idx).unwrap()
     }
@@ -631,6 +634,7 @@ impl Rope {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte_to_char(&self, byte_idx: usize) -> usize {
         self.try_byte_to_char(byte_idx).unwrap()
     }
@@ -650,6 +654,7 @@ impl Rope {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte_to_line(&self, byte_idx: usize) -> usize {
         self.try_byte_to_line(byte_idx).unwrap()
     }
@@ -667,6 +672,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_byte(&self, char_idx: usize) -> usize {
         self.try_char_to_byte(char_idx).unwrap()
     }
@@ -686,6 +692,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_line(&self, char_idx: usize) -> usize {
         self.try_char_to_line(char_idx).unwrap()
     }
@@ -703,6 +710,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_utf16_cu(&self, char_idx: usize) -> usize {
         self.try_char_to_utf16_cu(char_idx).unwrap()
     }
@@ -724,6 +732,7 @@ impl Rope {
     /// Panics if `utf16_cu_idx` is out of bounds
     /// (i.e. `utf16_cu_idx > len_utf16_cu()`).
     #[inline]
+    #[track_caller]
     pub fn utf16_cu_to_char(&self, utf16_cu_idx: usize) -> usize {
         self.try_utf16_cu_to_char(utf16_cu_idx).unwrap()
     }
@@ -742,6 +751,7 @@ impl Rope {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line_to_byte(&self, line_idx: usize) -> usize {
         self.try_line_to_byte(line_idx).unwrap()
     }
@@ -760,6 +770,7 @@ impl Rope {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line_to_char(&self, line_idx: usize) -> usize {
         self.try_line_to_char(line_idx).unwrap()
     }
@@ -775,6 +786,7 @@ impl Rope {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx >= len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte(&self, byte_idx: usize) -> u8 {
         // Bounds check
         if let Some(out) = self.get_byte(byte_idx) {
@@ -796,6 +808,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx >= len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char(&self, char_idx: usize) -> char {
         if let Some(out) = self.get_char(char_idx) {
             out
@@ -818,6 +831,7 @@ impl Rope {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx >= len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line(&self, line_idx: usize) -> RopeSlice {
         if let Some(out) = self.get_line(line_idx) {
             out
@@ -847,6 +861,7 @@ impl Rope {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn chunk_at_byte(&self, byte_idx: usize) -> (&str, usize, usize, usize) {
         // Bounds check
         if let Some(out) = self.get_chunk_at_byte(byte_idx) {
@@ -877,6 +892,7 @@ impl Rope {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn chunk_at_char(&self, char_idx: usize) -> (&str, usize, usize, usize) {
         if let Some(out) = self.get_chunk_at_char(char_idx) {
             out
@@ -909,6 +925,7 @@ impl Rope {
     ///
     /// Panics if `line_break_idx` is out of bounds (i.e. `line_break_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn chunk_at_line_break(&self, line_break_idx: usize) -> (&str, usize, usize, usize) {
         if let Some(out) = self.get_chunk_at_line_break(line_break_idx) {
             out
@@ -945,6 +962,7 @@ impl Rope {
     /// Panics if the start of the range is greater than the end, or if the
     /// end is out of bounds (i.e. `end > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn slice<R>(&self, char_range: R) -> RopeSlice
     where
         R: RangeBounds<usize>,
@@ -964,6 +982,7 @@ impl Rope {
     /// - The start of the range is greater than the end.
     /// - The end is out of bounds (i.e. `end > len_bytes()`).
     /// - The range doesn't align with char boundaries.
+    #[track_caller]
     pub fn byte_slice<R>(&self, byte_range: R) -> RopeSlice
     where
         R: RangeBounds<usize>,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -322,7 +322,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn byte_to_char(&self, byte_idx: usize) -> usize {
-        self.try_byte_to_char(byte_idx).unwrap()
+        self.try_byte_to_char(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the line index of the given byte.
@@ -342,7 +343,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn byte_to_line(&self, byte_idx: usize) -> usize {
-        self.try_byte_to_line(byte_idx).unwrap()
+        self.try_byte_to_line(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the byte index of the given char.
@@ -360,7 +362,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn char_to_byte(&self, char_idx: usize) -> usize {
-        self.try_char_to_byte(char_idx).unwrap()
+        self.try_char_to_byte(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the line index of the given char.
@@ -380,7 +383,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn char_to_line(&self, char_idx: usize) -> usize {
-        self.try_char_to_line(char_idx).unwrap()
+        self.try_char_to_line(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the utf16 code unit index of the given char.
@@ -398,7 +402,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn char_to_utf16_cu(&self, char_idx: usize) -> usize {
-        self.try_char_to_utf16_cu(char_idx).unwrap()
+        self.try_char_to_utf16_cu(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the char index of the given utf16 code unit.
@@ -420,7 +425,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn utf16_cu_to_char(&self, utf16_cu_idx: usize) -> usize {
-        self.try_utf16_cu_to_char(utf16_cu_idx).unwrap()
+        self.try_utf16_cu_to_char(utf16_cu_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the byte index of the start of the given line.
@@ -439,7 +445,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn line_to_byte(&self, line_idx: usize) -> usize {
-        self.try_line_to_byte(line_idx).unwrap()
+        self.try_line_to_byte(line_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the char index of the start of the given line.
@@ -458,7 +465,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn line_to_char(&self, line_idx: usize) -> usize {
-        self.try_line_to_char(line_idx).unwrap()
+        self.try_line_to_char(line_idx)
+            .expect("index out of bounds")
     }
 
     //-----------------------------------------------------------------------
@@ -474,16 +482,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn byte(&self, byte_idx: usize) -> u8 {
-        // Bounds check
-        if let Some(out) = self.get_byte(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of slice: byte index {}, slice byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_byte(byte_idx).expect("index out of bounds")
     }
 
     /// Returns the char at `char_idx`.
@@ -496,15 +495,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn char(&self, char_idx: usize) -> char {
-        if let Some(out) = self.get_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of slice: char index {}, slice char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_char(char_idx).expect("index out of bounds")
     }
 
     /// Returns the line at `line_idx`.
@@ -519,15 +510,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn line(&self, line_idx: usize) -> RopeSlice<'a> {
-        if let Some(out) = self.get_line(line_idx) {
-            out
-        } else {
-            let len_lines = self.len_lines();
-            panic!(
-                "Attempt to index past end of slice: line index {}, slice line length {}",
-                line_idx, len_lines
-            );
-        }
+        self.get_line(line_idx).expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given byte index.
@@ -548,7 +531,8 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[track_caller]
     pub fn chunk_at_byte(&self, byte_idx: usize) -> (&'a str, usize, usize, usize) {
-        self.try_chunk_at_byte(byte_idx).unwrap()
+        self.try_chunk_at_byte(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given char index.
@@ -569,15 +553,8 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[track_caller]
     pub fn chunk_at_char(&self, char_idx: usize) -> (&'a str, usize, usize, usize) {
-        if let Some(out) = self.get_chunk_at_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of slice: char index {}, slice char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chunk_at_char(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the chunk containing the given line break.
@@ -601,15 +578,8 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `line_break_idx` is out of bounds (i.e. `line_break_idx > len_lines()`).
     #[track_caller]
     pub fn chunk_at_line_break(&self, line_break_idx: usize) -> (&'a str, usize, usize, usize) {
-        if let Some(out) = self.get_chunk_at_line_break(line_break_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of Rope: line break index {}, max index {}",
-                line_break_idx,
-                self.len_lines()
-            );
-        }
+        self.get_chunk_at_line_break(line_break_idx)
+            .expect("index out of bounds")
     }
 
     /// Returns the entire contents of the `RopeSlice` as a `&str` if
@@ -666,7 +636,6 @@ impl<'a> RopeSlice<'a> {
             )
         };
 
-        // Bounds check
         assert!(start <= end);
         assert!(
             end <= self.len_chars(),
@@ -714,10 +683,8 @@ impl<'a> RopeSlice<'a> {
     where
         R: RangeBounds<usize>,
     {
-        match self.get_byte_slice_impl(byte_range) {
-            Ok(s) => return s,
-            Err(e) => panic!("byte_slice(): {}", e),
-        }
+        self.get_byte_slice_impl(byte_range)
+            .expect("index out of bounds or unaligned with char boundaries")
     }
 
     //-----------------------------------------------------------------------
@@ -760,15 +727,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn bytes_at(&self, byte_idx: usize) -> Bytes<'a> {
-        if let Some(out) = self.get_bytes_at(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: byte index {}, RopeSlice byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_bytes_at(byte_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the chars of the `RopeSlice`.
@@ -808,15 +767,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn chars_at(&self, char_idx: usize) -> Chars<'a> {
-        if let Some(out) = self.get_chars_at(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: char index {}, RopeSlice char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chars_at(char_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the lines of the `RopeSlice`.
@@ -859,15 +810,7 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn lines_at(&self, line_idx: usize) -> Lines<'a> {
-        if let Some(out) = self.get_lines_at(line_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: line index {}, RopeSlice line length {}",
-                line_idx,
-                self.len_lines()
-            );
-        }
+        self.get_lines_at(line_idx).expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `RopeSlice`.
@@ -913,15 +856,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn chunks_at_byte(&self, byte_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_byte(byte_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: byte index {}, RopeSlice byte length {}",
-                byte_idx,
-                self.len_bytes()
-            );
-        }
+        self.get_chunks_at_byte(byte_idx)
+            .expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `RopeSlice`, with the
@@ -944,15 +880,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn chunks_at_char(&self, char_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_char(char_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: char index {}, RopeSlice char length {}",
-                char_idx,
-                self.len_chars()
-            );
-        }
+        self.get_chunks_at_char(char_idx)
+            .expect("index out of bounds")
     }
 
     /// Creates an iterator over the chunks of the `RopeSlice`, with the
@@ -979,15 +908,8 @@ impl<'a> RopeSlice<'a> {
     #[inline]
     #[track_caller]
     pub fn chunks_at_line_break(&self, line_break_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
-        if let Some(out) = self.get_chunks_at_line_break(line_break_idx) {
-            out
-        } else {
-            panic!(
-                "Attempt to index past end of RopeSlice: line break index {}, RopeSlice line break max index {}",
-                line_break_idx,
-                self.len_lines()
-            );
-        }
+        self.get_chunks_at_line_break(line_break_idx)
+            .expect("index out of bounds")
     }
 }
 
@@ -1149,7 +1071,6 @@ impl<'a> RopeSlice<'a> {
     /// Non-panicking version of [`get_byte()`](RopeSlice::get_byte).
     #[inline]
     pub fn get_byte(&self, byte_idx: usize) -> Option<u8> {
-        // Bounds check
         if byte_idx < self.len_bytes() {
             let (chunk, chunk_byte_idx, _, _) = self.chunk_at_byte(byte_idx);
             let chunk_rel_byte_idx = byte_idx - chunk_byte_idx;
@@ -1162,7 +1083,6 @@ impl<'a> RopeSlice<'a> {
     /// Non-panicking version of [`char()`](RopeSlice::char).
     #[inline]
     pub fn get_char(&self, char_idx: usize) -> Option<char> {
-        // Bounds check
         if char_idx < self.len_chars() {
             let (chunk, _, chunk_char_idx, _) = self.chunk_at_char(char_idx);
             let byte_idx = char_to_byte_idx(chunk, char_idx - chunk_char_idx);

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -320,6 +320,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte_to_char(&self, byte_idx: usize) -> usize {
         self.try_byte_to_char(byte_idx).unwrap()
     }
@@ -339,6 +340,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte_to_line(&self, byte_idx: usize) -> usize {
         self.try_byte_to_line(byte_idx).unwrap()
     }
@@ -356,6 +358,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_byte(&self, char_idx: usize) -> usize {
         self.try_char_to_byte(char_idx).unwrap()
     }
@@ -375,6 +378,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_line(&self, char_idx: usize) -> usize {
         self.try_char_to_line(char_idx).unwrap()
     }
@@ -392,6 +396,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char_to_utf16_cu(&self, char_idx: usize) -> usize {
         self.try_char_to_utf16_cu(char_idx).unwrap()
     }
@@ -413,6 +418,7 @@ impl<'a> RopeSlice<'a> {
     /// Panics if `utf16_cu_idx` is out of bounds
     /// (i.e. `utf16_cu_idx > len_utf16_cu()`).
     #[inline]
+    #[track_caller]
     pub fn utf16_cu_to_char(&self, utf16_cu_idx: usize) -> usize {
         self.try_utf16_cu_to_char(utf16_cu_idx).unwrap()
     }
@@ -431,6 +437,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line_to_byte(&self, line_idx: usize) -> usize {
         self.try_line_to_byte(line_idx).unwrap()
     }
@@ -449,6 +456,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line_to_char(&self, line_idx: usize) -> usize {
         self.try_line_to_char(line_idx).unwrap()
     }
@@ -464,6 +472,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx >= len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn byte(&self, byte_idx: usize) -> u8 {
         // Bounds check
         if let Some(out) = self.get_byte(byte_idx) {
@@ -485,6 +494,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx >= len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn char(&self, char_idx: usize) -> char {
         if let Some(out) = self.get_char(char_idx) {
             out
@@ -507,6 +517,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx >= len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn line(&self, line_idx: usize) -> RopeSlice<'a> {
         if let Some(out) = self.get_line(line_idx) {
             out
@@ -535,6 +546,7 @@ impl<'a> RopeSlice<'a> {
     /// # Panics
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
+    #[track_caller]
     pub fn chunk_at_byte(&self, byte_idx: usize) -> (&'a str, usize, usize, usize) {
         self.try_chunk_at_byte(byte_idx).unwrap()
     }
@@ -555,6 +567,7 @@ impl<'a> RopeSlice<'a> {
     /// # Panics
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
+    #[track_caller]
     pub fn chunk_at_char(&self, char_idx: usize) -> (&'a str, usize, usize, usize) {
         if let Some(out) = self.get_chunk_at_char(char_idx) {
             out
@@ -586,6 +599,7 @@ impl<'a> RopeSlice<'a> {
     /// # Panics
     ///
     /// Panics if `line_break_idx` is out of bounds (i.e. `line_break_idx > len_lines()`).
+    #[track_caller]
     pub fn chunk_at_line_break(&self, line_break_idx: usize) -> (&'a str, usize, usize, usize) {
         if let Some(out) = self.get_chunk_at_line_break(line_break_idx) {
             out
@@ -632,6 +646,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if the start of the range is greater than the end, or the end
     /// is out of bounds (i.e. `end > len_chars()`).
+    #[track_caller]
     pub fn slice<R>(&self, char_range: R) -> RopeSlice<'a>
     where
         R: RangeBounds<usize>,
@@ -694,6 +709,7 @@ impl<'a> RopeSlice<'a> {
     /// - The start of the range is greater than the end.
     /// - The end is out of bounds (i.e. `end > len_bytes()`).
     /// - The range doesn't align with char boundaries.
+    #[track_caller]
     pub fn byte_slice<R>(&self, byte_range: R) -> RopeSlice<'a>
     where
         R: RangeBounds<usize>,
@@ -742,6 +758,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn bytes_at(&self, byte_idx: usize) -> Bytes<'a> {
         if let Some(out) = self.get_bytes_at(byte_idx) {
             out
@@ -789,6 +806,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn chars_at(&self, char_idx: usize) -> Chars<'a> {
         if let Some(out) = self.get_chars_at(char_idx) {
             out
@@ -839,6 +857,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `line_idx` is out of bounds (i.e. `line_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn lines_at(&self, line_idx: usize) -> Lines<'a> {
         if let Some(out) = self.get_lines_at(line_idx) {
             out
@@ -892,6 +911,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len_bytes()`).
     #[inline]
+    #[track_caller]
     pub fn chunks_at_byte(&self, byte_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
         if let Some(out) = self.get_chunks_at_byte(byte_idx) {
             out
@@ -922,6 +942,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `char_idx` is out of bounds (i.e. `char_idx > len_chars()`).
     #[inline]
+    #[track_caller]
     pub fn chunks_at_char(&self, char_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
         if let Some(out) = self.get_chunks_at_char(char_idx) {
             out
@@ -956,6 +977,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// Panics if `line_break_idx` is out of bounds (i.e. `line_break_idx > len_lines()`).
     #[inline]
+    #[track_caller]
     pub fn chunks_at_line_break(&self, line_break_idx: usize) -> (Chunks<'a>, usize, usize, usize) {
         if let Some(out) = self.get_chunks_at_line_break(line_break_idx) {
             out


### PR DESCRIPTION
When using panicking versions of the `Rope` methods, IMO it's better to get the location where you didn't respect the invariants that lead to the panic over the location of the methods in `ropey`'s code.