### PR TITLE
Add serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ small_chunks = []
 [dependencies]
 smallvec = "1.0.0"
 str_indices = { version = "0.4", default-features = false }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -33,6 +34,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 unicode-segmentation = "1.3"
 fnv = "1"
 fxhash = "0.2"
+serde_json = "1"
 
 # This is a transitive dependency of criterion--we don't use it directly. We
 # lock it to this exact version because newer versions don't work on our MSRV,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::type_complexity)]
 
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_json;
 extern crate smallvec;
 extern crate str_indices;
 


### PR DESCRIPTION
Adds a `serde` feature, which makes `Rope` implement `serde::Serialize` and `serde::Deserialize`, (de)serializing as if it were a `String`.

---

I tested this by running:

```sh
cargo check
cargo check --features serde
cargo test
cargo test --features serde
```
