### PR TITLE
Fix `BackingArray` undefined behavior

### DIFF
--- a/src/tree/node_text.rs
+++ b/src/tree/node_text.rs
@@ -237,6 +237,7 @@ mod inner {
 
     /// The backing internal buffer type for `NodeText`.
     #[derive(Copy, Clone)]
+    #[repr(transparent)]
     struct BackingArray([u8; MAX_BYTES]);
 
     /// We need a very specific size of array, which is not necessarily


### PR DESCRIPTION
`BackingArray` unsafe-impls `smallvec::Array`, which represents a promise to the smallvec crate that a raw pointer to BackingArray can be casted into a raw pointer to a u8. However, without this commit, this is undefined behavior, as the layout of Rust structs is unspecified unless a `repr` annotation is used to ensure a specific layout.

This commit fixed this problem by marking `BackingArray` as `repr(transparent)` to ensure it has the same layout as `[u8; MAX_BYTES]`.

This also fixes the `field `0` is never read` warning that previously occurred when running `cargo check`.