### PR TITLE
minor: Fix closing backticks for Bytes::reversed doc codefence

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -204,6 +204,7 @@ impl<'a> Bytes<'a> {
     ///     println!("{} {}", i, b);
     /// #   assert_eq!(b, rope.byte(rope.len_bytes() - i - 1));
     /// }
+    /// ```
     #[inline]
     #[must_use]
     pub fn reversed(mut self) -> Bytes<'a> {


### PR DESCRIPTION
Super minor change - I noticed the `Bytes::reversed` iterator rustdoc example was missing its closing triple-backtick. Rustdoc doesn't seem to have a problem with it but it can mess up highlighting in an editor for example ;)