### PR TITLE
Ropey 2.0: Add support for constructing `RopeSlice`s from `&str`s.

### DIFF
--- a/src/chunk_cursor.rs
+++ b/src/chunk_cursor.rs
@@ -28,7 +28,7 @@ struct StackItem<'a> {
 /// Cursor API for traversing the chunks of a rope.
 #[derive(Debug, Clone)]
 pub struct ChunkCursor<'a> {
-    // The node stack can be empty if If the node stack is empty, that means
+    // Note: empty and ignored when `str_slice` below is `Some`.
     node_stack: Vec<StackItem<'a>>,
 
     // If this is `Some`, then the chunk cursor is operating on a string slice,

--- a/src/chunk_cursor.rs
+++ b/src/chunk_cursor.rs
@@ -317,6 +317,10 @@ impl<'a> ChunkCursor<'a> {
         }
     }
 
+    pub(crate) fn is_from_str_slice(&self) -> bool {
+        self.str_slice.is_some()
+    }
+
     /// Attempts to advance the cursor to the next chunk that contains a line
     /// boundary.
     ///

--- a/src/chunk_cursor.rs
+++ b/src/chunk_cursor.rs
@@ -546,7 +546,7 @@ impl<'a> ChunkCursor<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{rope_builder::RopeBuilder, Rope};
+    use crate::{rope_builder::RopeBuilder, Rope, RopeSlice};
 
     // 127 bytes, 103 chars, 1 line
     const TEXT: &str = "Hello there!  How're you doing?  It's \
@@ -793,6 +793,33 @@ mod tests {
     }
 
     #[test]
+    fn chunk_cursor_07() {
+        let texts = [TEXT, ""];
+        for text in texts {
+            let t: RopeSlice = text.into();
+
+            let mut cursor = t.chunk_cursor();
+
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+
+            assert_eq!(false, cursor.next());
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+
+            assert_eq!(false, cursor.prev());
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+        }
+    }
+
+    #[test]
     fn chunk_cursor_at_01() {
         let r = Rope::from_str(TEXT);
 
@@ -851,6 +878,23 @@ mod tests {
             let s = r.slice(..i);
             let cursor = s.chunk_cursor_at(i);
             assert_eq!("A", cursor.chunk());
+        }
+    }
+
+    #[test]
+    fn chunk_cursor_at_04() {
+        let texts = [TEXT, ""];
+        for text in texts {
+            let t: RopeSlice = text.into();
+
+            for i in 0..=text.len() {
+                let cursor = t.chunk_cursor_at(i);
+
+                assert!(cursor.at_first());
+                assert!(cursor.at_last());
+                assert_eq!(cursor.byte_offset(), 0);
+                assert_eq!(cursor.chunk(), text);
+            }
         }
     }
 
@@ -1054,5 +1098,36 @@ mod tests {
         while cursor.prev_with_line_boundary(LF_CR).is_some() {}
         assert!(cursor.at_first());
         assert_eq!(0, cursor.byte_offset());
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn chunk_cursor_line_boundary_05() {
+        use crate::LineType::LF_CR;
+        let l_text = lines_text();
+        let texts = [&l_text, ""];
+        for text in texts {
+            let t: RopeSlice = text.into();
+            let mut cursor = t.chunk_cursor();
+
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+
+            // Forward.
+            assert!(cursor.next_with_line_boundary(LF_CR).is_none());
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+
+            // Backward.
+            assert!(cursor.prev_with_line_boundary(LF_CR).is_none());
+            assert!(cursor.at_first());
+            assert!(cursor.at_last());
+            assert_eq!(cursor.byte_offset(), 0);
+            assert_eq!(cursor.chunk(), text);
+        }
     }
 }

--- a/src/chunk_cursor.rs
+++ b/src/chunk_cursor.rs
@@ -32,12 +32,13 @@ pub struct ChunkCursor<'a> {
     node_stack: Vec<StackItem<'a>>,
 
     // If this is `Some`, then the chunk cursor is operating on a string slice,
-    // not a normal rope.  In that case, the node stack should be empty and all
-    // operations ignore it.
+    // not a normal rope.  In that case, `node_stack` above is unused and should
+    // be empty.
     str_slice: Option<&'a str>,
 
-    // The byte range within the root node that is considered part of this
-    // cursor's contents.
+    // The byte range within the root node/string slice that is considered part
+    // of this cursor's contents. For string slices this should always be set to
+    // `[0, length_of_str]`.
     byte_range: [usize; 2],
 }
 

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -27,7 +27,7 @@ pub trait RopeExt {
     /// This method does not panic itself.  However, if edits are attempted
     /// on the resulting `Rope` with the panicking variants `insert()` and
     /// `remove()`, they will panic.
-    fn to_owning_slice(&self) -> crate::Rope;
+    fn to_owning_slice(&self) -> Option<crate::Rope>;
 
     // fn is_instance(&self, other: &Self) -> bool;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -19,6 +19,9 @@ pub trait RopeExt {
     /// for it are rare, and you should stick to normal `Rope`s and `RopeSlice`s
     /// when you can.
     ///
+    /// Returns `None` if the `RopeSlice` is from a `&str` rather than from a
+    /// `Rope` (see the `From` impl for building `RopeSlice`s from `&str`s).
+    ///
     /// Runs in O(1) time.  Space usage is constant unless the original `Rope`
     /// is edited, causing the otherwise shared contents to diverge.
     ///

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1998,6 +1998,7 @@ mod tests {
         assert!(lines.next().is_none());
     }
 
+    #[cfg(feature = "metric_lines_lf_cr")]
     #[test]
     #[cfg_attr(miri, ignore)]
     fn lines_20() {

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -474,6 +474,11 @@ impl Rope {
     // `crate::shared_impl`.
 
     #[inline(always)]
+    fn get_str_text(&self) -> Option<&str> {
+        None
+    }
+
+    #[inline(always)]
     fn get_root(&self) -> &Node {
         &self.root
     }
@@ -764,8 +769,8 @@ impl Rope {
 
 impl crate::extra::RopeExt for Rope {
     #[inline]
-    fn to_owning_slice(&self) -> Rope {
-        self.clone()
+    fn to_owning_slice(&self) -> Option<Rope> {
+        Some(self.clone())
     }
 }
 

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -1108,8 +1108,8 @@ macro_rules! shared_std_impls {
                             return compared;
                         }
 
-                        chunk1 = &[];
                         chunk2 = &chunk2[chunk1.len()..];
+                        chunk1 = &[];
                     }
 
                     if chunk1.is_empty() {

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -1,6 +1,7 @@
 //! The definitions in this module assume that the following methods are defined
 //! on both Rope and RopeSlice:
 //!
+//! - `get_str_text()`: for RopeSlice::Str returns the underlying &str.
 //! - `get_root()`: returns the root node of the Rope or RopeSlice.
 //! - `get_root_info()`: returns the TextInfo of the root node.
 //! - `get_byte_range()`: returns the range of bytes of the root node that are
@@ -30,6 +31,10 @@ macro_rules! shared_main_impl_methods {
         #[cfg(feature = "metric_chars")]
         #[inline]
         pub fn len_chars(&self) -> usize {
+            if let Some(text) = self.get_str_text() {
+                return str_indices::chars::count(text);
+            }
+
             if let Some(info) = self.get_full_info() {
                 info.chars
             } else {
@@ -48,6 +53,10 @@ macro_rules! shared_main_impl_methods {
         #[cfg(feature = "metric_utf16")]
         #[inline]
         pub fn len_utf16(&self) -> usize {
+            if let Some(text) = self.get_str_text() {
+                return str_indices::utf16::count(text);
+            }
+
             if let Some(info) = self.get_full_info() {
                 info.utf16
             } else {
@@ -69,6 +78,10 @@ macro_rules! shared_main_impl_methods {
         ))]
         #[inline]
         pub fn len_lines(&self, line_type: LineType) -> usize {
+            if let Some(text) = self.get_str_text() {
+                return crate::str_utils::lines::count_breaks(text, line_type) + 1;
+            }
+
             if let Some(info) = self.get_full_info() {
                 info.line_breaks(line_type) + 1
             } else {
@@ -92,6 +105,10 @@ macro_rules! shared_main_impl_methods {
         pub fn is_char_boundary(&self, byte_idx: usize) -> bool {
             assert!(byte_idx <= self.len());
 
+            if let Some(text) = self.get_str_text() {
+                return text.is_char_boundary(byte_idx);
+            }
+
             let (text, offset) = self.chunk(byte_idx);
             crate::is_char_boundary(byte_idx - offset, text.as_bytes())
         }
@@ -108,6 +125,10 @@ macro_rules! shared_main_impl_methods {
         pub fn floor_char_boundary(&self, byte_idx: usize) -> usize {
             assert!(byte_idx <= self.len());
 
+            if let Some(text) = self.get_str_text() {
+                return crate::floor_char_boundary(byte_idx, text.as_bytes());
+            }
+
             let (text, offset) = self.chunk(byte_idx);
             offset + crate::floor_char_boundary(byte_idx - offset, text.as_bytes())
         }
@@ -123,6 +144,10 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn ceil_char_boundary(&self, byte_idx: usize) -> usize {
             assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return crate::ceil_char_boundary(byte_idx, text.as_bytes());
+            }
 
             let (text, offset) = self.chunk(byte_idx);
             offset + crate::ceil_char_boundary(byte_idx - offset, text.as_bytes())
@@ -151,8 +176,11 @@ macro_rules! shared_main_impl_methods {
                 return None;
             }
 
-            let (last_chunk, offset) = self.chunk(self.len() - 1);
+            if let Some(text) = self.get_str_text() {
+                return str_utils::lines::trailing_line_break_idx(text, line_type);
+            }
 
+            let (last_chunk, offset) = self.chunk(self.len() - 1);
             str_utils::lines::trailing_line_break_idx(last_chunk, line_type).map(|idx| offset + idx)
         }
 
@@ -253,6 +281,10 @@ macro_rules! shared_main_impl_methods {
         pub fn byte_to_char_idx(&self, byte_idx: usize) -> usize {
             assert!(byte_idx <= self.len());
 
+            if let Some(text) = self.get_str_text() {
+                return str_indices::chars::from_byte_idx(text, byte_idx);
+            }
+
             if self.get_full_info().is_some() {
                 self._byte_to_char_idx(byte_idx)
             } else {
@@ -279,6 +311,11 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn char_to_byte_idx(&self, char_idx: usize) -> usize {
             assert!(char_idx <= self.len_chars());
+
+            if let Some(text) = self.get_str_text() {
+                return str_indices::chars::to_byte_idx(text, char_idx);
+            }
+
             if self.get_full_info().is_some() {
                 self._char_to_byte_idx(char_idx)
             } else {
@@ -308,6 +345,11 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn byte_to_utf16_idx(&self, byte_idx: usize) -> usize {
             assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return str_indices::utf16::from_byte_idx(text, byte_idx);
+            }
+
             if self.get_full_info().is_some() {
                 self._byte_to_utf16_idx(byte_idx)
             } else {
@@ -338,6 +380,11 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn utf16_to_byte_idx(&self, utf16_idx: usize) -> usize {
             assert!(utf16_idx <= self.len_utf16());
+
+            if let Some(text) = self.get_str_text() {
+                return str_indices::utf16::to_byte_idx(text, utf16_idx);
+            }
+
             if self.get_full_info().is_some() {
                 self._utf16_to_byte_idx(utf16_idx)
             } else {
@@ -371,6 +418,11 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> usize {
             assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return crate::str_utils::lines::from_byte_idx(text, byte_idx, line_type);
+            }
+
             if self.get_full_info().is_some() {
                 self._byte_to_line_idx(byte_idx, line_type)
             } else {
@@ -410,6 +462,11 @@ macro_rules! shared_main_impl_methods {
         #[inline]
         pub fn line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> usize {
             assert!(line_idx <= self.len_lines(line_type));
+
+            if let Some(text) = self.get_str_text() {
+                return crate::str_utils::lines::to_byte_idx(text, line_idx, line_type);
+            }
+
             if self.get_full_info().is_some() {
                 self._line_to_byte_idx(line_idx, line_type)
             } else {
@@ -428,6 +485,10 @@ macro_rules! shared_main_impl_methods {
         /// Runs in O(log N) time.
         #[inline]
         pub fn bytes(&self) -> Bytes<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return Bytes::from_str(text, 0);
+            }
+
             Bytes::new(
                 &self.get_root(),
                 self.get_root_info(),
@@ -449,6 +510,12 @@ macro_rules! shared_main_impl_methods {
         /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
         #[inline]
         pub fn bytes_at(&self, byte_idx: usize) -> Bytes<$rlt> {
+            assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return Bytes::from_str(text, byte_idx);
+            }
+
             Bytes::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -462,6 +529,10 @@ macro_rules! shared_main_impl_methods {
         /// Runs in O(log N) time.
         #[inline]
         pub fn chars(&self) -> Chars<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return Chars::from_str(text, 0);
+            }
+
             Chars::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -486,6 +557,12 @@ macro_rules! shared_main_impl_methods {
         /// - If `byte_idx` is not a char boundary.
         #[inline]
         pub fn chars_at(&self, byte_idx: usize) -> Chars<$rlt> {
+            assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return Chars::from_str(text, byte_idx);
+            }
+
             Chars::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -509,6 +586,10 @@ macro_rules! shared_main_impl_methods {
         ))]
         #[inline]
         pub fn lines(&self, line_type: LineType) -> Lines<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return Lines::from_str(text, 0, line_type);
+            }
+
             Lines::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -541,6 +622,10 @@ macro_rules! shared_main_impl_methods {
         ))]
         #[inline]
         pub fn lines_at(&self, line_idx: usize, line_type: LineType) -> Lines<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return Lines::from_str(text, line_idx, line_type);
+            }
+
             Lines::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -555,6 +640,10 @@ macro_rules! shared_main_impl_methods {
         /// Runs in O(log N) time.
         #[inline]
         pub fn chunks(&self) -> Chunks<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return Chunks::from_str(text, 0).0;
+            }
+
             Chunks::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -581,6 +670,12 @@ macro_rules! shared_main_impl_methods {
         /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
         #[inline]
         pub fn chunks_at(&self, byte_idx: usize) -> (Chunks<$rlt>, usize) {
+            assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return Chunks::from_str(text, byte_idx);
+            }
+
             let (chunks, start_idx) = Chunks::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -597,6 +692,10 @@ macro_rules! shared_main_impl_methods {
         /// Runs in O(log N) time.
         #[inline]
         pub fn chunk_cursor(&self) -> ChunkCursor<$rlt> {
+            if let Some(text) = self.get_str_text() {
+                return ChunkCursor::from_str(text);
+            }
+
             ChunkCursor::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -619,6 +718,12 @@ macro_rules! shared_main_impl_methods {
         /// Panics if `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
         #[inline]
         pub fn chunk_cursor_at(&self, byte_idx: usize) -> ChunkCursor<$rlt> {
+            assert!(byte_idx <= self.len());
+
+            if let Some(text) = self.get_str_text() {
+                return ChunkCursor::from_str(text);
+            }
+
             ChunkCursor::new(
                 self.get_root(),
                 self.get_root_info(),
@@ -629,6 +734,10 @@ macro_rules! shared_main_impl_methods {
 
         /// Returns the text as a string slice if it's contiguous in memory.
         pub fn as_str(&self) -> Option<&$rlt str> {
+            if let Some(text) = self.get_str_text() {
+                return Some(text);
+            }
+
             match self.get_root() {
                 Node::Leaf(text) => {
                     Some(&text.text()[self.get_byte_range()[0]..self.get_byte_range()[1]])
@@ -642,6 +751,10 @@ macro_rules! shared_main_impl_methods {
 
         #[inline(always)]
         fn get_full_info(&self) -> Option<&TextInfo> {
+            if let Some(_) = self.get_str_text() {
+                return None;
+            }
+
             let range = self.get_byte_range();
             let root_info = self.get_root_info();
             if range[0] == 0 && range[1] == root_info.bytes {
@@ -653,24 +766,40 @@ macro_rules! shared_main_impl_methods {
 
         #[cfg(feature = "metric_chars")]
         fn _byte_to_char_idx(&self, byte_idx: usize) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_byte(byte_idx);
             start_info.chars + text.byte_to_char_idx(byte_idx - start_info.bytes)
         }
 
         #[cfg(feature = "metric_chars")]
         fn _char_to_byte_idx(&self, char_idx: usize) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_char(char_idx);
             start_info.bytes + text.char_to_byte_idx(char_idx - start_info.chars)
         }
 
         #[cfg(feature = "metric_utf16")]
         fn _byte_to_utf16_idx(&self, byte_idx: usize) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_byte(byte_idx);
             start_info.utf16 + text.byte_to_utf16_idx(byte_idx - start_info.bytes)
         }
 
         #[cfg(feature = "metric_utf16")]
         fn _utf16_to_byte_idx(&self, utf16_idx: usize) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_utf16(utf16_idx);
             start_info.bytes + text.utf16_to_byte_idx(utf16_idx - start_info.utf16)
         }
@@ -681,6 +810,10 @@ macro_rules! shared_main_impl_methods {
             feature = "metric_lines_unicode"
         ))]
         fn _byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_byte(byte_idx);
 
             start_info.line_breaks(line_type)
@@ -693,6 +826,10 @@ macro_rules! shared_main_impl_methods {
             feature = "metric_lines_unicode"
         ))]
         fn _line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> usize {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             let (text, start_info) = self.get_root().get_text_at_line_break(line_idx, line_type);
 
             start_info.bytes
@@ -711,6 +848,10 @@ macro_rules! shared_main_impl_methods {
             feature = "metric_lines_unicode"
         ))]
         pub(crate) fn _is_relevant_crlf_split(&self, byte_idx: usize, line_type: LineType) -> bool {
+            if let Some(_) = self.get_str_text() {
+                panic!("This case should be handled at a higher level.");
+            }
+
             self.get_root().is_relevant_crlf_split(byte_idx, line_type)
         }
     };
@@ -772,6 +913,14 @@ macro_rules! shared_no_panic_impl_methods {
                 return None;
             }
 
+            if let Some(text) = self.get_str_text() {
+                use crate::str_utils::lines;
+                let start_byte = lines::to_byte_idx(text, line_idx, line_type);
+                let end_byte = lines::to_byte_idx(text, line_idx + 1, line_type);
+
+                return Some((&text[start_byte..end_byte]).into());
+            }
+
             let start_byte = self.line_to_byte_idx(line_idx, line_type);
             let end_byte = self.line_to_byte_idx(line_idx + 1, line_type);
 
@@ -781,6 +930,10 @@ macro_rules! shared_no_panic_impl_methods {
         fn get_chunk(&self, byte_idx: usize) -> Option<(&$rlt str, usize)> {
             if byte_idx > self.len() {
                 return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some((text, 0));
             }
 
             let (chunk, start_byte) = self

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -235,7 +235,7 @@ impl<'a> From<&'a str> for RopeSlice<'a> {
     /// - Most operations become `O(N)` rather than `O(log N)`.  For short
     ///   strings this doesn't matter, but for long strings this can have
     ///   significant negative performance impacts.
-    /// - [`RopeExt::to_owning_slice()`](crate::extra::RopeExt::to_owning_slice())
+    /// - [`slice_to_owning_slice()`](crate::extra::slice_to_owning_slice())
     ///   will return `None`.
     ///
     /// Runs in O(1) time.

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -252,10 +252,13 @@ impl<'a> From<&'a Rope> for RopeSlice<'a> {
 impl<'a> From<&'a str> for RopeSlice<'a> {
     /// Creates a `RopeSlice` directly from a string slice.
     ///
-    /// **IMPORTANT:** `RopeSlice`s created this way don't have the same
-    /// performance guarantees as normal slices.  Specifically, most operations
-    /// become `O(N)` rather than `O(log N)`.  For short string slices this
-    /// doesn't matter, but for long ones it very much can.
+    /// **Warning:** `RopeSlice`s created this way aren't normal `RopeSlice`s:
+    ///
+    /// - Most operations become `O(N)` rather than `O(log N)`.  For short
+    ///   strings this doesn't matter, but for long strings this can have
+    ///   significant negative performance impacts.
+    /// - [`RopeExt::to_owning_slice()`](crate::extra::RopeExt::to_owning_slice())
+    ///   will return `None`.
     ///
     /// Runs in O(1) time.
     #[inline(always)]


### PR DESCRIPTION
In Ropey 1.x you could do `"Some string slice".into()` to build a `RopeSlice` from a plain string slice, but this wasn't implemented in Ropey 2.0.

The rationale for omitting this feature from Ropey 2.0 was:

1. Rope slices aren't string slices.
2. The initial reason for implementing this in Ropey 1.x was actually just to allow client code to do certain esoteric optimizations (as noted in the documentation), and was never intended as a generally useful feature.
3. `RopeSlice`s constructed this way are a significant performance footgun if the `&str` they are constructed from is very long, because the performance of almost all operations on `&str`-derived `RopeSlice`s is actually O(N) rather than the documented O(log N).

Nevertheless, in practice it's turned out to be useful to do this in a variety of circumstances, and some code bases have come to rely on this feature quite deeply in their code.  Moreover, it's the only way to construct `'static` `RopeSlice`s, which is needed for them to be a true analog to `&str` for `Rope`s.

Therefore, this PR adds this feature to Ropey 2.0, but with a warning in the documentation about its performance implications with long `&str`.