### PR TITLE
V2: Add a `CharIndices` cursor-like Iterator

### DIFF
--- a/src/rope.rs
+++ b/src/rope.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::{
     end_bound_to_num,
-    iter::{Bytes, Chars, Chunks},
+    iter::{Bytes, CharIndices, Chars, Chunks},
     rope_builder::RopeBuilder,
     slice::RopeSlice,
     start_bound_to_num, str_utils,

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -558,7 +558,7 @@ macro_rules! shared_main_impl_methods {
             ).unwrap()
         }
 
-        /// Creates an iterator over the chars of the `Rope`, starting at the char
+        /// Creates an iterator over the chars of the `Rope`, starting
         /// at `byte_idx`.
         ///
         /// Note that this takes a **byte index**, not a char index.

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -592,6 +592,43 @@ macro_rules! shared_main_impl_methods {
             }
         }
 
+        /// Creates an iterator over the chars of the `Rope`, and their positions.
+        ///
+        /// On each call to [`next`](CharIndices::next) or [`prev`](CharIndices::prev)
+        /// this iterator returns the **byte index** where the returned character
+        /// starts.
+        ///
+        /// Runs in O(log N) time.
+        #[track_caller]
+        #[inline]
+        pub fn char_indices(&self) -> CharIndices<$rlt> {
+            CharIndices::new(self.chars())
+        }
+
+        /// Creates an iterator over the chars of the `Rope`, and their positions,
+        /// starting at `byte_idx`.
+        ///
+        /// Note that this takes a **byte index**, not a char index.
+        ///
+        /// If `byte_idx == len()` then an iterator at the end of the
+        /// `Rope` is created (i.e. `next()` will return `None`).
+        ///
+        /// On each call to [`next`](CharIndices::next) or [`prev`](CharIndices::prev)
+        /// this iterator returns the **byte index** where the returned character
+        /// starts.
+        ///
+        /// Runs in O(log N) time.
+        ///
+        /// # Panics
+        ///
+        /// - If `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
+        /// - If `byte_idx` is not a char boundary.
+        #[track_caller]
+        #[inline]
+        pub fn char_indices_at(&self, byte_idx: usize) -> CharIndices<$rlt> {
+            CharIndices::new(self.chars_at(byte_idx))
+        }
+
         /// Creates an iterator over the lines of the `Rope`.
         ///
         /// Note: the iterator will iterate over lines according to the passed

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,7 +2,7 @@ use std::ops::RangeBounds;
 
 use crate::{
     end_bound_to_num,
-    iter::{Bytes, Chars, Chunks},
+    iter::{Bytes, CharIndices, Chars, Chunks},
     start_bound_to_num,
     tree::{Node, TextInfo},
     ChunkCursor,

--- a/tests/proptest_tests.rs
+++ b/tests/proptest_tests.rs
@@ -452,6 +452,34 @@ proptest::proptest! {
             assert_eq!(idx, 0);
         }
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn pt_char_indices_iter_next(ref text in "\\n{0,5}\\PC{0,100}\\n{0,5}\\PC{0,100}\\n{0,5}") {
+        let r = Rope::from_str(text);
+        for t in make_test_data(&r, text, ..) {
+            let mut offset = 0;
+            for (byte_idx, ch) in t.char_indices() {
+                assert_eq!(offset, byte_idx);
+                offset += ch.len_utf8();
+            }
+            assert_eq!(offset, t.len());
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn pt_char_indices_iter_prev(ref text in "\\n{0,5}\\PC{0,100}\\n{0,5}\\PC{0,100}\\n{0,5}") {
+        let r = Rope::from_str(text);
+        for t in make_test_data(&r, text, ..) {
+            let mut offset = t.len();
+            for (byte_idx, ch) in t.char_indices_at(t.len()).reversed() {
+                offset -= ch.len_utf8();
+                assert_eq!(offset, byte_idx);
+            }
+            assert_eq!(offset, 0);
+        }
+    }
 }
 
 //===========================================================================


### PR DESCRIPTION
`CharIndices` can be useful in some cases where you want the byte index of a char. It can be created on top of `Chars` outside of this crate but within this crate we can reuse `Chars`' current byte index information so that `CharIndices` does not need to track this info itself.

`CharIndices` mirrors `Bytes` and `Chars` in being cursor-like: it can be reversed and you can use `next` and `prev` to go forward and backward (depending on whether the cursor is reversed).

This type didn't necessarily make sense in the V1 API because you could count the number of chars returned by `Chars` and slice based on that character index. With V2 though, exposing byte indices fits the API better.

I also added a commit that fixes a typo I saw in the docs for `chars_at`