### PR TITLE
Allow CI for pull requests against all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
   schedule:
     # Every-other month, to make sure new Rust
     # releases don't break things.


### PR DESCRIPTION
Minor change here to allow CI for PRs against all branches. I had this in mind so that we could check https://github.com/cessen/ropey/pull/106 at a glance (without you needing to pull down the branch and run the checks against it manually). For the v2.0 branch specifically we could just modify it to be `branches: [ master, 2.0-alpha ]` but IME if you're opening a PR and CI is fast... might as well run it.