### PR TITLE
Add note on line break behavior for empty rope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,10 @@
 //! _after_ line breaks to be the start of new lines.  And it treats
 //! line breaks as being a part of the lines they mark the end of.
 //!
-//! For example, the rope `"Hello"` has a single line: `"Hello"`.  The
-//! rope `"Hello\nworld"` has two lines: `"Hello\n"` and `"world"`.  And
-//! the rope `"Hello\nworld\n"` has three lines: `"Hello\n"`,
-//! `"world\n"`, and `""`.
+//! For example, the rope `""` has a single line.  The rope `"Hello"` has a
+//! single line as well: `"Hello"`.  The rope `"Hello\nworld"` has two lines:
+//! `"Hello\n"` and `"world"`.  And the rope `"Hello\nworld\n"` has three lines:
+//! `"Hello\n"`, `"world\n"`, and `""`.
 //!
 //! Ropey can be configured at build time via feature flags to recognize
 //! different line breaks.  Ropey always recognizes:


### PR DESCRIPTION
I tripped over the fact that an empty buffer will return a line from the `lines` iterator. It was a bit unexpected since it deviates from the behavior of `str::lines` (which returns no lines in that case). That is probably fine (and difficult to change at this point anyway), but I think a bit more documentation might be useful here, so I added it. The diff looks more involved than it actually is; all I did was add a sentence to the paragraph.

Thanks for your work on this project!