### PR TITLE
fix(benches): properly reset rope state in remove benchmarks

### DIFF
--- a/benches/remove.rs
+++ b/benches/remove.rs
@@ -34,7 +34,7 @@ fn remove_small(c: &mut Criterion) {
             let end = (start + 1).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -50,7 +50,7 @@ fn remove_small(c: &mut Criterion) {
             let end = (start + 1).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -66,7 +66,7 @@ fn remove_small(c: &mut Criterion) {
             let end = (start + 1).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -82,7 +82,7 @@ fn remove_small(c: &mut Criterion) {
             let start = end - (1).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -104,7 +104,7 @@ fn remove_medium(c: &mut Criterion) {
             let end = (start + 15).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -120,7 +120,7 @@ fn remove_medium(c: &mut Criterion) {
             let end = (start + 15).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -136,7 +136,7 @@ fn remove_medium(c: &mut Criterion) {
             let end = (start + 15).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })
@@ -152,7 +152,7 @@ fn remove_medium(c: &mut Criterion) {
             let start = end - (15).min(len);
             rope.remove(start..end);
 
-            if rope.len_bytes() == TEXT.len() / 2 {
+            if rope.len_bytes() < TEXT.len() / 2 {
                 rope = Rope::from_str(&text);
             }
         })


### PR DESCRIPTION
In the remove benchmarks it seems unintentional to only reset the rope text if it hits exactly half of the original length. This causes many iterations where the rope is empty and thus makes the benchmark seem faster than it actually is :) (about 50% on `remove_medium`, almost no impact on `remove_small`)