### PR TITLE
Add traits for non-panicking methods

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "ropey"
-version = "2.0.0-alpha"
+version = "2.0.0-beta.1"
 dependencies = [
  "str_indices",
 ]

--- a/fuzz/fuzz_targets/mutation.rs
+++ b/fuzz/fuzz_targets/mutation.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::{
     arbitrary::{self, Arbitrary},
     fuzz_target,
 };
-use ropey::Rope;
+use ropey::{extra::RopeNoPanicMut as _, Rope};
 
 const SMALL_TEXT: &str = include_str!("small.txt");
 

--- a/fuzz/fuzz_targets/mutation_small_chunks.rs
+++ b/fuzz/fuzz_targets/mutation_small_chunks.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::{
     arbitrary::{self, Arbitrary},
     fuzz_target,
 };
-use ropey::Rope;
+use ropey::{extra::RopeNoPanicMut as _, Rope};
 
 const SMALL_TEXT: &str = include_str!("small.txt");
 

--- a/src/chunk_cursor.rs
+++ b/src/chunk_cursor.rs
@@ -587,7 +587,7 @@ impl<'a> ChunkCursor<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{rope_builder::RopeBuilder, Rope, RopeSlice};
+    use crate::{extra::RopeNoPanic, rope_builder::RopeBuilder, Rope, RopeSlice};
 
     // 127 bytes, 103 chars, 1 line
     const TEXT: &str = "Hello there!  How're you doing?  It's \
@@ -978,6 +978,154 @@ mod tests {
     fn chunk_cursor_at_10() {
         let r = RopeSlice::from("foo");
         r.chunk_cursor_at(4);
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_01() {
+        let r = Rope::from_str(TEXT);
+
+        for i in 0..=TEXT.len() {
+            let cursor = RopeNoPanic::get_chunk_cursor_at(&r, i)
+                .expect("`get_chunk_cursor_at` should not fail");
+            let chunk = cursor.chunk();
+            let byte_offset = cursor.byte_offset();
+
+            assert!(i >= byte_offset && i <= (byte_offset + chunk.len()));
+            assert_eq!(&TEXT[byte_offset..(byte_offset + chunk.len())], chunk);
+        }
+
+        let cursor_1 = RopeNoPanic::get_chunk_cursor_at(&r, TEXT.len() - 1)
+            .expect("`get_chunk_cursor_at` should not fail");
+        let cursor_2 = RopeNoPanic::get_chunk_cursor_at(&r, TEXT.len())
+            .expect("`get_chunk_cursor_at` should not fail");
+        assert_eq!(cursor_1.byte_offset(), cursor_2.byte_offset());
+        assert_eq!(cursor_1.chunk(), cursor_2.chunk());
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(5..124);
+        let text = &TEXT[5..124];
+
+        for i in 0..=text.len() {
+            let cursor = RopeNoPanic::get_chunk_cursor_at(&s, i)
+                .expect("`get_chunk_cursor_at` should not fail");
+            let chunk = cursor.chunk();
+            let byte_offset = cursor.byte_offset();
+
+            assert!(i >= byte_offset && i <= (byte_offset + chunk.len()));
+            assert_eq!(&text[byte_offset..(byte_offset + chunk.len())], chunk);
+        }
+
+        let cursor_1 = RopeNoPanic::get_chunk_cursor_at(&s, text.len() - 1)
+            .expect("`get_chunk_cursor_at` should not fail");
+        let cursor_2 = RopeNoPanic::get_chunk_cursor_at(&s, text.len())
+            .expect("`get_chunk_cursor_at` should not fail");
+        assert_eq!(cursor_1.byte_offset(), cursor_2.byte_offset());
+        assert_eq!(cursor_1.chunk(), cursor_2.chunk());
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_03() {
+        // This tests a subtle corner case where the slice end aligns with
+        // an internal chunk boundary, which would erronerously cause the
+        // chunk cursor to be created on an empty chunk just *after* the slice
+        // contents.  It requires a lot of nodes to trigger, because it needs
+        // the tree to have enough depth.
+        let r = {
+            let mut rb = RopeBuilder::new();
+            for _ in 0..100 {
+                rb._append_chunk_as_leaf("A");
+            }
+            rb.finish()
+        };
+
+        for i in 1..=100 {
+            let s = r.slice(..i);
+            let cursor = RopeNoPanic::get_chunk_cursor_at(&s, i)
+                .expect("`get_chunk_cursor_at` should not fail");
+            assert_eq!("A", cursor.chunk());
+        }
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_04() {
+        let r = Rope::from_str("foo");
+        assert!(matches!(
+            RopeNoPanic::get_chunk_cursor_at(&r, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_05() {
+        let r = Rope::from_str("foo");
+        let s = r.slice(1..2);
+        assert!(matches!(
+            RopeNoPanic::get_chunk_cursor_at(&s, 2),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_06() {
+        let texts = [TEXT, ""];
+        for text in texts {
+            let t: RopeSlice = text.into();
+
+            for i in 0..=text.len() {
+                let cursor = RopeNoPanic::get_chunk_cursor_at(&t, i)
+                    .expect("`get_chunk_cursor_at` should not fail");
+
+                assert!(cursor.at_first());
+                assert!(cursor.at_last());
+                assert_eq!(cursor.byte_offset(), 0);
+                assert_eq!(cursor.chunk(), text);
+            }
+        }
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_07() {
+        let r = RopeSlice::from("");
+        assert!(RopeNoPanic::get_chunk_cursor_at(&r, 0).is_ok());
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_08() {
+        let r = RopeSlice::from("");
+        assert!(matches!(
+            RopeNoPanic::get_chunk_cursor_at(&r, 1),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_09() {
+        let r = RopeSlice::from("foo");
+        assert!(RopeNoPanic::get_chunk_cursor_at(&r, 3).is_ok());
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_10() {
+        let r = RopeSlice::from("foo");
+        assert!(matches!(
+            RopeNoPanic::get_chunk_cursor_at(&r, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunk_cursor_at_11() {
+        let r = Rope::from_str(TEXT);
+
+        let cursor = {
+            let s = r.slice(4..32);
+            RopeNoPanic::get_chunk_cursor_at(&s, 0).expect("`get_chunk_cursor_at` should not fail")
+        };
+
+        _ = cursor;
     }
 
     #[cfg(feature = "metric_lines_lf_cr")]

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -8,7 +8,7 @@
 use crate::{iter::Lines, LineType};
 use crate::{
     iter::{Bytes, CharIndices, Chars, Chunks},
-    RopeSlice,
+    ChunkCursor, RopeSlice,
 };
 
 pub mod esoterica {
@@ -353,4 +353,12 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `Err`.
     fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'original>, usize)>;
+
+    /// Non-panicking version of `chunk_cursor_at`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `Err`.
+    fn get_chunk_cursor_at(
+        &'current self,
+        byte_idx: usize,
+    ) -> crate::Result<ChunkCursor<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -281,4 +281,22 @@ pub trait RopeNoPanic<'current, 'original> {
         feature = "metric_lines_unicode"
     ))]
     fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize>;
+
+    /// Non-panicking version of `line_to_byte_idx`.
+    ///
+    /// If `line_idx` is out of bounds, returns `None`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        )))
+    )]
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -214,4 +214,9 @@ pub trait RopeNoPanic<'current, 'original> {
         line_idx: usize,
         line_type: LineType,
     ) -> Option<RopeSlice<'original>>;
+
+    /// Non-panicking version of `chunk()`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'original str, usize)>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -371,3 +371,12 @@ pub trait RopeNoPanic<'current, 'original> {
     where
         R: RangeBounds<usize>;
 }
+
+/// A trait implementing non-panicking versions of the editing methods that are present on [`Rope`](crate::Rope).
+pub trait RopeNoPanicMut {
+    /// Non-panicking version of `insert()`.
+    ///
+    /// On failure this leaves the rope untouched and returns the cause of the
+    /// failure.
+    fn try_insert(&mut self, byte_idx: usize, text: &str) -> crate::Result<()>;
+}

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -1,5 +1,13 @@
 //! Miscellaneous extra functionality.
 
+#[cfg(any(
+    feature = "metric_lines_lf",
+    feature = "metric_lines_lf_cr",
+    feature = "metric_lines_unicode"
+))]
+use crate::LineType;
+use crate::RopeSlice;
+
 pub mod esoterica {
     //! Esoteric functionality.
     //!
@@ -169,7 +177,7 @@ pub mod esoterica {
 
 /// A trait implementing non-panicking versions of the read-only methods that are present on both
 /// [`Rope`](crate::Rope) and [`RopeSlice`](crate::RopeSlice).
-pub trait RopeNoPanic {
+pub trait RopeNoPanic<'current, 'original> {
     /// Non-panicking version of `byte()`.
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
@@ -184,4 +192,26 @@ pub trait RopeNoPanic {
     ///
     /// On failure returns the cause of failure.
     fn get_char(&self, byte_idx: usize) -> crate::Result<char>;
+
+    /// Non-panicking version of `line()`.
+    ///
+    /// If `line_idx` is out of bounds, returns `None`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        )))
+    )]
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> Option<RopeSlice<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -219,4 +219,9 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
     fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'original str, usize)>;
+
+    /// Non-panicking version of `is_char_boundary()`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -234,4 +234,11 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
     fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `byte_to_char_idx`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "metric_chars")))]
+    #[cfg(feature = "metric_chars")]
+    fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -174,4 +174,14 @@ pub trait RopeNoPanic {
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
     fn get_byte(&self, byte_idx: usize) -> Option<u8>;
+
+    /// Non-panicking version of `char()`.
+    ///
+    /// Will fail if `byte_idx` is either:
+    ///
+    /// - Not a char boundary.
+    /// - Out of bounds.
+    ///
+    /// On failure returns the cause of failure.
+    fn get_char(&self, byte_idx: usize) -> crate::Result<char>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -248,4 +248,11 @@ pub trait RopeNoPanic<'current, 'original> {
     #[cfg_attr(docsrs, doc(cfg(feature = "metric_chars")))]
     #[cfg(feature = "metric_chars")]
     fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `byte_to_utf16_idx`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "metric_utf16")))]
+    #[cfg(feature = "metric_utf16")]
+    fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -379,4 +379,10 @@ pub trait RopeNoPanicMut {
     /// On failure this leaves the rope untouched and returns the cause of the
     /// failure.
     fn try_insert(&mut self, byte_idx: usize, text: &str) -> crate::Result<()>;
+
+    /// Non-panicking version of `insert_char()`.
+    ///
+    /// On failure this leaves the rope untouched and returns the cause of the
+    /// failure.
+    fn try_insert_char(&mut self, byte_idx: usize, ch: char) -> crate::Result<()>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -229,4 +229,9 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
     fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `ceil_char_boundary()`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -6,7 +6,10 @@
     feature = "metric_lines_unicode"
 ))]
 use crate::LineType;
-use crate::{iter::Bytes, RopeSlice};
+use crate::{
+    iter::{Bytes, Chars},
+    RopeSlice,
+};
 
 pub mod esoterica {
     //! Esoteric functionality.
@@ -304,4 +307,12 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `Err`.
     fn get_bytes_at(&'current self, byte_idx: usize) -> crate::Result<Bytes<'original>>;
+
+    /// Non-panicking version of `chars_at`.
+    ///
+    /// Returns `Err` if:
+    ///
+    /// - `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
+    /// - `byte_idx` is not a char boundary.
+    fn get_chars_at(&'current self, byte_idx: usize) -> crate::Result<Chars<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -166,3 +166,12 @@ pub mod esoterica {
         }
     }
 }
+
+/// A trait implementing non-panicking versions of the read-only methods that are present on both
+/// [`Rope`](crate::Rope) and [`RopeSlice`](crate::RopeSlice).
+pub trait RopeNoPanic {
+    /// Non-panicking version of `byte()`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    fn get_byte(&self, byte_idx: usize) -> Option<u8>;
+}

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -5,7 +5,7 @@
     feature = "metric_lines_lf_cr",
     feature = "metric_lines_unicode"
 ))]
-use crate::LineType;
+use crate::{iter::Lines, LineType};
 use crate::{
     iter::{Bytes, CharIndices, Chars},
     RopeSlice,
@@ -326,4 +326,26 @@ pub trait RopeNoPanic<'current, 'original> {
         &'current self,
         byte_idx: usize,
     ) -> crate::Result<CharIndices<'original>>;
+
+    /// Non-panicking version of `lines_at`.
+    ///
+    /// If `line_idx` is out of bounds, returns `Err`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        )))
+    )]
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_lines_at(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> crate::Result<Lines<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -1,5 +1,7 @@
 //! Miscellaneous extra functionality.
 
+use std::ops::RangeBounds;
+
 #[cfg(any(
     feature = "metric_lines_lf",
     feature = "metric_lines_lf_cr",
@@ -361,4 +363,11 @@ pub trait RopeNoPanic<'current, 'original> {
         &'current self,
         byte_idx: usize,
     ) -> crate::Result<ChunkCursor<'original>>;
+
+    /// Non-panicking version of `slice()`.
+    ///
+    /// On failure this returns the cause of the failure.
+    fn try_slice<R>(&'current self, byte_range: R) -> crate::Result<RopeSlice<'original>>
+    where
+        R: RangeBounds<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -385,4 +385,12 @@ pub trait RopeNoPanicMut {
     /// On failure this leaves the rope untouched and returns the cause of the
     /// failure.
     fn try_insert_char(&mut self, byte_idx: usize, ch: char) -> crate::Result<()>;
+
+    /// Non-panicking version of `remove()`.
+    ///
+    /// On failure this leaves the rope untouched and returns the cause of the
+    /// failure.
+    fn try_remove<R>(&mut self, byte_range: R) -> crate::Result<()>
+    where
+        R: RangeBounds<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -7,7 +7,7 @@
 ))]
 use crate::LineType;
 use crate::{
-    iter::{Bytes, Chars},
+    iter::{Bytes, CharIndices, Chars},
     RopeSlice,
 };
 
@@ -315,4 +315,15 @@ pub trait RopeNoPanic<'current, 'original> {
     /// - `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
     /// - `byte_idx` is not a char boundary.
     fn get_chars_at(&'current self, byte_idx: usize) -> crate::Result<Chars<'original>>;
+
+    /// Non-panicking version of `char_indices_at`.
+    ///
+    /// Returns `Err` if:
+    ///
+    /// - `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
+    /// - `byte_idx` is not a char boundary.
+    fn get_char_indices_at(
+        &'current self,
+        byte_idx: usize,
+    ) -> crate::Result<CharIndices<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -6,7 +6,7 @@
     feature = "metric_lines_unicode"
 ))]
 use crate::LineType;
-use crate::RopeSlice;
+use crate::{iter::Bytes, RopeSlice};
 
 pub mod esoterica {
     //! Esoteric functionality.
@@ -299,4 +299,9 @@ pub trait RopeNoPanic<'current, 'original> {
         feature = "metric_lines_unicode"
     ))]
     fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize>;
+
+    /// Non-panicking version of `bytes_at`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `Err`.
+    fn get_bytes_at(&'current self, byte_idx: usize) -> crate::Result<Bytes<'original>>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -7,7 +7,7 @@
 ))]
 use crate::{iter::Lines, LineType};
 use crate::{
-    iter::{Bytes, CharIndices, Chars},
+    iter::{Bytes, CharIndices, Chars, Chunks},
     RopeSlice,
 };
 
@@ -348,4 +348,9 @@ pub trait RopeNoPanic<'current, 'original> {
         line_idx: usize,
         line_type: LineType,
     ) -> crate::Result<Lines<'original>>;
+
+    /// Non-panicking version of `chunks_at`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `Err`.
+    fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'original>, usize)>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -241,4 +241,11 @@ pub trait RopeNoPanic<'current, 'original> {
     #[cfg_attr(docsrs, doc(cfg(feature = "metric_chars")))]
     #[cfg(feature = "metric_chars")]
     fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `char_to_byte_idx`.
+    ///
+    /// If `char_idx` is out of bounds, returns `None`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "metric_chars")))]
+    #[cfg(feature = "metric_chars")]
+    fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -263,4 +263,22 @@ pub trait RopeNoPanic<'current, 'original> {
     #[cfg_attr(docsrs, doc(cfg(feature = "metric_utf16")))]
     #[cfg(feature = "metric_utf16")]
     fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `byte_to_line_idx`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        )))
+    )]
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -224,4 +224,9 @@ pub trait RopeNoPanic<'current, 'original> {
     ///
     /// If `byte_idx` is out of bounds, returns `None`.
     fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool>;
+
+    /// Non-panicking version of `floor_char_boundary()`.
+    ///
+    /// If `byte_idx` is out of bounds, returns `None`.
+    fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize>;
 }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -255,4 +255,12 @@ pub trait RopeNoPanic<'current, 'original> {
     #[cfg_attr(docsrs, doc(cfg(feature = "metric_utf16")))]
     #[cfg(feature = "metric_utf16")]
     fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize>;
+
+    /// Non-panicking version of `utf16_to_byte_idx`.
+    ///
+    /// If `utf16_idx` is out of bounds, returns `None`.
+    /// (i.e. `utf16_idx > len_utf16()`).
+    #[cfg_attr(docsrs, doc(cfg(feature = "metric_utf16")))]
+    #[cfg(feature = "metric_utf16")]
+    fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize>;
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1274,6 +1274,101 @@ mod tests {
     }
 
     #[test]
+    fn get_chunks_at_01() {
+        let r = Rope::from_str(TEXT);
+
+        for t in make_test_data(&r, TEXT, ..) {
+            for i in 0..TEXT.len() {
+                let mut current_byte = t.chunk(i).1;
+                let (chunks, idx) =
+                    RopeNoPanic::get_chunks_at(&t, i).expect("`get_chunks_at` should not fail");
+                assert_eq!(current_byte, idx);
+
+                for chunk1 in chunks {
+                    let chunk2 = t.chunk(current_byte).0;
+                    assert_eq!(chunk2, chunk1);
+                    current_byte += chunk2.len();
+                }
+            }
+
+            let (mut chunks, idx) = RopeNoPanic::get_chunks_at(&t, TEXT.len())
+                .expect("`get_chunks_at` should not fail");
+            assert_eq!(TEXT.len(), idx);
+            assert_eq!(None, chunks.next());
+        }
+    }
+
+    #[test]
+    fn get_chunks_at_02() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, ..) {
+            let s = t.slice(5..124);
+            let text = &TEXT[5..124];
+
+            for i in 0..text.len() {
+                let mut current_byte = s.chunk(i).1;
+                let (chunks, idx) =
+                    RopeNoPanic::get_chunks_at(&s, i).expect("`get_chunks_at` should not fail");
+                assert_eq!(current_byte, idx);
+
+                for chunk1 in chunks {
+                    let chunk2 = s.chunk(current_byte).0;
+                    assert_eq!(chunk2, chunk1);
+                    current_byte += chunk2.len();
+                }
+            }
+
+            let (mut chunks, idx) = RopeNoPanic::get_chunks_at(&s, text.len())
+                .expect("`get_chunks_at` should not fail");
+            assert_eq!(text.len(), idx);
+            assert_eq!(None, chunks.next());
+        }
+    }
+
+    #[test]
+    fn get_chunks_at_03() {
+        let r = Rope::from_str("foo");
+        assert!(matches!(
+            RopeNoPanic::get_chunks_at(&r, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunks_at_04() {
+        let r = Rope::from_str("foo");
+        let s = r.slice(1..2);
+        assert!(matches!(
+            RopeNoPanic::get_chunks_at(&s, 2),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunks_at_05() {
+        let s = RopeSlice::from("foo");
+
+        assert!(matches!(
+            RopeNoPanic::get_chunks_at(&s, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chunks_at_06() {
+        let r = Rope::from_str(TEXT);
+
+        let chunks = {
+            let s = r.slice(4..32);
+            RopeNoPanic::get_chunks_at(&s, 0)
+                .expect("`get_chunks_at` should not fail")
+                .0
+        };
+
+        _ = chunks;
+    }
+
+    #[test]
     #[cfg_attr(miri, ignore)]
     fn chunks_iter_size_hint_01() {
         let r = Rope::from_str(TEXT);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1659,6 +1659,74 @@ mod tests {
     }
 
     #[test]
+    fn get_chars_at_01() {
+        let r = Rope::from_str(TEXT);
+
+        for t in make_test_data(&r, TEXT, ..) {
+            for i in 0..TEXT.len() {
+                if !TEXT.is_char_boundary(i) {
+                    assert!(matches!(
+                        RopeNoPanic::get_chars_at(&t, i),
+                        Err(crate::Error::NonCharBoundary)
+                    ));
+                    continue;
+                }
+                let mut chars =
+                    RopeNoPanic::get_chars_at(&t, i).expect("`get_chars_at` should not fail");
+                assert_eq!(TEXT[i..].chars().next(), chars.next());
+            }
+
+            let mut chars = t.chars_at(TEXT.len());
+            assert_eq!(None, chars.next());
+        }
+    }
+
+    #[test]
+    fn get_chars_at_02() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, ..) {
+            let s = t.slice(5..124);
+            let text = &TEXT[5..124];
+
+            for i in 0..text.len() {
+                if !text.is_char_boundary(i) {
+                    assert!(matches!(
+                        RopeNoPanic::get_chars_at(&s, i),
+                        Err(crate::Error::NonCharBoundary)
+                    ));
+                    continue;
+                }
+
+                let mut chars =
+                    RopeNoPanic::get_chars_at(&s, i).expect("`get_chars_at` should not fail");
+                assert_eq!(text[i..].chars().next(), chars.next());
+            }
+
+            let mut chars = s.chars_at(text.len());
+            assert_eq!(None, chars.next());
+        }
+    }
+
+    #[test]
+    fn get_chars_at_03() {
+        let r = Rope::from_str("foo");
+        assert!(matches!(
+            RopeNoPanic::get_chars_at(&r, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_chars_at_04() {
+        let r = Rope::from_str("foo");
+        let s = r.slice(1..2);
+        assert!(matches!(
+            RopeNoPanic::get_chars_at(&s, 2),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
     #[cfg_attr(miri, ignore)]
     fn chars_iter_size_hint_01() {
         let r = Rope::from_str(TEXT);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -965,7 +965,7 @@ mod tests {
 
     use super::*;
 
-    use crate::{rope_builder::RopeBuilder, Rope, RopeSlice};
+    use crate::{extra::RopeNoPanic, rope_builder::RopeBuilder, Rope, RopeSlice};
 
     #[cfg(feature = "metric_lines_lf_cr")]
     use crate::LineType;
@@ -1429,6 +1429,70 @@ mod tests {
         let r = Rope::from_str("foo");
         let s = r.slice(1..2);
         s.bytes_at(2);
+    }
+
+    #[test]
+    fn get_bytes_at_01() {
+        let r = Rope::from_str(TEXT);
+
+        for t in make_test_data(&r, TEXT, ..) {
+            for i in 0..TEXT.len() {
+                let mut bytes =
+                    RopeNoPanic::get_bytes_at(&t, i).expect("`get_bytes_at` should not fail");
+                assert_eq!(TEXT.as_bytes()[i], bytes.next().unwrap());
+            }
+
+            let mut bytes =
+                RopeNoPanic::get_bytes_at(&t, TEXT.len()).expect("`get_bytes_at` should not fail");
+            assert_eq!(None, bytes.next());
+        }
+    }
+
+    #[test]
+    fn get_bytes_at_02() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, ..) {
+            let s = t.slice(5..124);
+            let text = &TEXT[5..124];
+
+            for i in 0..text.len() {
+                let mut bytes =
+                    RopeNoPanic::get_bytes_at(&s, i).expect("`get_bytes_at` should not fail");
+                assert_eq!(text.as_bytes()[i], bytes.next().unwrap());
+            }
+
+            let mut bytes =
+                RopeNoPanic::get_bytes_at(&s, text.len()).expect("`get_bytes_at` should not fail");
+            assert_eq!(None, bytes.next());
+        }
+    }
+
+    #[test]
+    fn get_bytes_at_03() {
+        let r = Rope::from_str("foo");
+        assert!(matches!(
+            RopeNoPanic::get_bytes_at(&r, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_bytes_at_04() {
+        let r = Rope::from_str("foo");
+        let s = r.slice(1..2);
+        assert!(matches!(
+            RopeNoPanic::get_bytes_at(&s, 2),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn get_bytes_at_05() {
+        let s = RopeSlice::from("foo");
+        assert!(matches!(
+            RopeNoPanic::get_bytes_at(&s, 4),
+            Err(crate::Error::OutOfBounds)
+        ));
     }
 
     #[test]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2402,6 +2402,104 @@ mod tests {
     #[cfg(feature = "metric_lines_lf_cr")]
     #[test]
     #[cfg_attr(miri, ignore)]
+    fn get_lines_at_01() {
+        let text = lines_text();
+        let r = Rope::from_str(&text);
+        for t in make_test_data(&r, &text, ..) {
+            for i in 0..t.len_lines(LineType::LF_CR) {
+                let line = t.line(i, LineType::LF_CR);
+                let mut lines = RopeNoPanic::get_lines_at(&t, i, LineType::LF_CR)
+                    .expect("`get_lines_at` should not fail");
+                assert_eq!(Some(line), lines.next());
+            }
+
+            let mut lines =
+                RopeNoPanic::get_lines_at(&t, t.len_lines(LineType::LF_CR), LineType::LF_CR)
+                    .expect("`get_lines_at` should not fail");
+            assert_eq!(None, lines.next());
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn get_lines_at_02() {
+        let text = lines_text();
+        let r = Rope::from_str(&text);
+        for t in make_test_data(&r, &text, ..) {
+            let s = t.slice(34..2031);
+
+            for i in 0..s.len_lines(LineType::LF_CR) {
+                let line = s.line(i, LineType::LF_CR);
+                let mut lines = RopeNoPanic::get_lines_at(&s, i, LineType::LF_CR)
+                    .expect("`get_lines_at` should not fail");
+                assert_eq!(Some(line), lines.next());
+            }
+
+            let mut lines =
+                RopeNoPanic::get_lines_at(&s, s.len_lines(LineType::LF_CR), LineType::LF_CR)
+                    .expect("`get_lines_at` should not fail");
+            assert_eq!(None, lines.next());
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn get_lines_at_03() {
+        let text = lines_text();
+        let r = Rope::from_str(&text);
+        for t in make_test_data(&r, &text, ..) {
+            let s = t.slice(34..34);
+
+            let mut lines = RopeNoPanic::get_lines_at(&s, 0, LineType::LF_CR)
+                .expect("`get_lines_at` should not fail");
+            assert_eq!("", lines.next().unwrap());
+
+            let mut lines = RopeNoPanic::get_lines_at(&s, 1, LineType::LF_CR)
+                .expect("`get_lines_at` should not fail");
+            assert_eq!(None, lines.next());
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_lines_at_04() {
+        let r = Rope::from_str("AA\nA");
+        assert!(matches!(
+            RopeNoPanic::get_lines_at(&r, 3, LineType::LF_CR),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_lines_at_05() {
+        let r = Rope::from_str("AA\nA");
+        let s = r.slice(1..2);
+        assert!(matches!(
+            RopeNoPanic::get_lines_at(&s, 2, LineType::LF_CR),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_lines_at_06() {
+        let r = Rope::from_str(TEXT);
+
+        let lines = {
+            let s = r.slice(4..32);
+            RopeNoPanic::get_lines_at(&s, 0, LineType::LF_CR)
+                .expect("`get_lines_at` should not fail")
+        };
+
+        _ = lines;
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    #[cfg_attr(miri, ignore)]
     fn lines_iter_size_hint_01() {
         let text = lines_text();
         let r = Rope::from_str(&text);

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
-use crate::extra::RopeNoPanic;
+use crate::extra::{RopeNoPanic, RopeNoPanicMut};
 use crate::{
     end_bound_to_num,
     extra::esoterica,
@@ -529,7 +529,7 @@ impl Rope {
     ///
     /// On failure this leaves the rope untouched and returns the cause of the
     /// failure.
-    pub fn try_insert(&mut self, byte_idx: usize, text: &str) -> Result<()> {
+    fn try_insert_impl(&mut self, byte_idx: usize, text: &str) -> Result<()> {
         if byte_idx > self.len() {
             return Err(OutOfBounds);
         }
@@ -915,6 +915,12 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     }
 }
 
+impl RopeNoPanicMut for Rope {
+    fn try_insert(&mut self, byte_idx: usize, text: &str) -> crate::Result<()> {
+        self.try_insert_impl(byte_idx, text)
+    }
+}
+
 //==============================================================
 // Stdlib trait impls.
 //
@@ -1245,6 +1251,209 @@ mod tests {
         {
             let mut r = r.clone();
             r.insert(10, "\n");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+    }
+
+    #[test]
+    fn try_insert_01() {
+        let mut r = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_insert(&mut r, 3, "AA").expect("`try_insert` should not fail");
+
+        assert_eq!(
+            r,
+            "HelAAlo there!  How're you doing?  It's \
+             a fine day, isn't it?  Aren't you glad \
+             we're alive?  こんにちは、みんなさん！"
+        );
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_02() {
+        let mut r = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_insert(&mut r, 0, "AA").expect("`try_insert` should not fail");
+
+        assert_eq!(
+            r,
+            "AAHello there!  How're you doing?  It's \
+             a fine day, isn't it?  Aren't you glad \
+             we're alive?  こんにちは、みんなさん！"
+        );
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_03() {
+        let mut r = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_insert(&mut r, 127, "AA").expect("`try_insert` should not fail");
+
+        assert_eq!(
+            r,
+            "Hello there!  How're you doing?  It's \
+             a fine day, isn't it?  Aren't you glad \
+             we're alive?  こんにちは、みんなさん！AA"
+        );
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_04() {
+        let mut r = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_insert(&mut r, 3, "").expect("`try_insert` should not fail");
+
+        assert_eq!(
+            r,
+            "Hello there!  How're you doing?  It's \
+             a fine day, isn't it?  Aren't you glad \
+             we're alive?  こんにちは、みんなさん！"
+        );
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_05() {
+        let mut r = Rope::new();
+        RopeNoPanicMut::try_insert(&mut r, 0, "He").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 2, "l").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 3, "l").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 4, "o w").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 7, "o").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 8, "rl").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 10, "d!").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 3, "zopter").expect("`try_insert` should not fail");
+
+        assert_eq!("Helzopterlo world!", r);
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_06() {
+        let mut r = Rope::new();
+        RopeNoPanicMut::try_insert(&mut r, 0, "こんいちは、みんなさん！")
+            .expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 21, "zopter").expect("`try_insert` should not fail");
+        assert_eq!("こんいちは、みzopterんなさん！", r);
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_07() {
+        let mut r = Rope::new();
+        RopeNoPanicMut::try_insert(&mut r, 0, "こ").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 3, "ん").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 6, "い").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 9, "ち").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 12, "は").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 15, "、").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 18, "み").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 21, "ん").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 24, "な").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 27, "さ").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 30, "ん").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 33, "！").expect("`try_insert` should not fail");
+        RopeNoPanicMut::try_insert(&mut r, 21, "zopter").expect("`try_insert` should not fail");
+        assert_eq!("こんいちは、みzopterんなさん！", r);
+
+        r.assert_invariants();
+    }
+
+    #[test]
+    fn try_insert_08() {
+        let mut r = Rope::from_str(TEXT);
+
+        assert_eq!(
+            RopeNoPanicMut::try_insert(&mut r, 128, "A"),
+            Err(crate::Error::OutOfBounds)
+        );
+
+        // Rope did not change
+        assert_eq!(TEXT, r);
+    }
+
+    #[test]
+    fn try_insert_09() {
+        let mut r = Rope::from_str(TEXT);
+
+        assert_eq!(
+            RopeNoPanicMut::try_insert(&mut r, 128, ""),
+            Err(crate::Error::OutOfBounds)
+        );
+
+        // Rope did not change
+        assert_eq!(TEXT, r);
+    }
+
+    #[test]
+    fn try_insert_10() {
+        let mut r = Rope::from_str(TEXT);
+
+        assert_eq!(
+            RopeNoPanicMut::try_insert(&mut r, 126, "A"),
+            Err(crate::Error::NonCharBoundary)
+        );
+
+        // Rope did not change
+        assert_eq!(TEXT, r);
+    }
+
+    #[test]
+    fn try_insert_11() {
+        let mut r = Rope::from_str(TEXT);
+
+        assert_eq!(
+            RopeNoPanicMut::try_insert(&mut r, 126, ""),
+            Err(crate::Error::NonCharBoundary)
+        );
+
+        // Rope did not change
+        assert_eq!(TEXT, r);
+    }
+
+    #[test]
+    fn try_insert_12() {
+        let (r, _) = make_rope_and_text_from_chunks(&["\n\r", "\r\n", "\n\r", "\r\n", "\n\r"]);
+
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 0, "\r").expect("`try_insert` should not fail");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 2, "\n").expect("`try_insert` should not fail");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 4, "\r").expect("`try_insert` should not fail");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 6, "\n").expect("`try_insert` should not fail");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 8, "\r").expect("`try_insert` should not fail");
+            r.assert_no_crlf_splits();
+            r.assert_accurate_text_info();
+        }
+        {
+            let mut r = r.clone();
+            RopeNoPanicMut::try_insert(&mut r, 10, "\n").expect("`try_insert` should not fail");
             r.assert_no_crlf_splits();
             r.assert_accurate_text_info();
         }

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -832,6 +832,11 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize> {
         self.get_ceil_char_boundary_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_chars")]
+    fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize> {
+        self.get_byte_to_char_idx_impl(byte_idx)
+    }
 }
 
 //==============================================================
@@ -1318,6 +1323,31 @@ mod tests {
         assert_eq!(102, r.byte_to_char_idx(125));
         assert_eq!(102, r.byte_to_char_idx(126));
         assert_eq!(103, r.byte_to_char_idx(127));
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_byte_to_char_idx_01() {
+        let r = Rope::from_str(TEXT);
+
+        assert_eq!(Some(0), RopeNoPanic::get_byte_to_char_idx(&r, 0));
+        assert_eq!(Some(1), RopeNoPanic::get_byte_to_char_idx(&r, 1));
+        assert_eq!(Some(2), RopeNoPanic::get_byte_to_char_idx(&r, 2));
+
+        assert_eq!(Some(91), RopeNoPanic::get_byte_to_char_idx(&r, 91));
+        assert_eq!(Some(91), RopeNoPanic::get_byte_to_char_idx(&r, 92));
+        assert_eq!(Some(91), RopeNoPanic::get_byte_to_char_idx(&r, 93));
+
+        assert_eq!(Some(92), RopeNoPanic::get_byte_to_char_idx(&r, 94));
+        assert_eq!(Some(92), RopeNoPanic::get_byte_to_char_idx(&r, 95));
+        assert_eq!(Some(92), RopeNoPanic::get_byte_to_char_idx(&r, 96));
+
+        assert_eq!(Some(102), RopeNoPanic::get_byte_to_char_idx(&r, 124));
+        assert_eq!(Some(102), RopeNoPanic::get_byte_to_char_idx(&r, 125));
+        assert_eq!(Some(102), RopeNoPanic::get_byte_to_char_idx(&r, 126));
+        assert_eq!(Some(103), RopeNoPanic::get_byte_to_char_idx(&r, 127));
+
+        assert_eq!(None, RopeNoPanic::get_byte_to_char_idx(&r, 128));
     }
 
     #[cfg(feature = "metric_chars")]

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -899,6 +899,13 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'current>, usize)> {
         self.get_chunks_at_impl(byte_idx)
     }
+
+    fn get_chunk_cursor_at(
+        &'current self,
+        byte_idx: usize,
+    ) -> crate::Result<ChunkCursor<'current>> {
+        self.get_chunk_cursor_at_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -837,6 +837,11 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize> {
         self.get_byte_to_char_idx_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_chars")]
+    fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize> {
+        self.get_char_to_byte_idx_impl(char_idx)
+    }
 }
 
 //==============================================================
@@ -1366,6 +1371,26 @@ mod tests {
 
         assert_eq!(124, r.char_to_byte_idx(102));
         assert_eq!(127, r.char_to_byte_idx(103));
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_char_to_byte_idx_01() {
+        let r = Rope::from_str(TEXT);
+
+        assert_eq!(Some(0), RopeNoPanic::get_char_to_byte_idx(&r, 0));
+        assert_eq!(Some(1), RopeNoPanic::get_char_to_byte_idx(&r, 1));
+        assert_eq!(Some(2), RopeNoPanic::get_char_to_byte_idx(&r, 2));
+
+        assert_eq!(Some(91), RopeNoPanic::get_char_to_byte_idx(&r, 91));
+        assert_eq!(Some(94), RopeNoPanic::get_char_to_byte_idx(&r, 92));
+        assert_eq!(Some(97), RopeNoPanic::get_char_to_byte_idx(&r, 93));
+        assert_eq!(Some(100), RopeNoPanic::get_char_to_byte_idx(&r, 94));
+
+        assert_eq!(Some(124), RopeNoPanic::get_char_to_byte_idx(&r, 102));
+        assert_eq!(Some(127), RopeNoPanic::get_char_to_byte_idx(&r, 103));
+
+        assert_eq!(None, RopeNoPanic::get_char_to_byte_idx(&r, 104));
     }
 
     #[cfg(feature = "metric_utf16")]

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -870,6 +870,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize> {
         self.get_line_to_byte_idx_impl(line_idx, line_type)
     }
+
+    fn get_bytes_at(&'current self, byte_idx: usize) -> Result<Bytes<'current>> {
+        self.get_bytes_at_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -895,6 +895,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     ) -> Result<Lines<'current>> {
         self.get_lines_at_impl(line_idx, line_type)
     }
+
+    fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'current>, usize)> {
+        self.get_chunks_at_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -842,6 +842,11 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize> {
         self.get_char_to_byte_idx_impl(char_idx)
     }
+
+    #[cfg(feature = "metric_utf16")]
+    fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize> {
+        self.get_byte_to_utf16_idx_impl(byte_idx)
+    }
 }
 
 //==============================================================
@@ -1417,6 +1422,34 @@ mod tests {
         assert_eq!(97, r.byte_to_utf16_idx(105));
 
         assert_eq!(111, r.byte_to_utf16_idx(143));
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_01() {
+        let r = Rope::from_str(TEXT_EMOJI);
+
+        assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&r, 0));
+
+        assert_eq!(Some(12), RopeNoPanic::get_byte_to_utf16_idx(&r, 12));
+        assert_eq!(Some(12), RopeNoPanic::get_byte_to_utf16_idx(&r, 13));
+        assert_eq!(Some(14), RopeNoPanic::get_byte_to_utf16_idx(&r, 16));
+
+        assert_eq!(Some(33), RopeNoPanic::get_byte_to_utf16_idx(&r, 35));
+        assert_eq!(Some(33), RopeNoPanic::get_byte_to_utf16_idx(&r, 36));
+        assert_eq!(Some(35), RopeNoPanic::get_byte_to_utf16_idx(&r, 39));
+
+        assert_eq!(Some(63), RopeNoPanic::get_byte_to_utf16_idx(&r, 67));
+        assert_eq!(Some(63), RopeNoPanic::get_byte_to_utf16_idx(&r, 70));
+        assert_eq!(Some(65), RopeNoPanic::get_byte_to_utf16_idx(&r, 71));
+
+        assert_eq!(Some(95), RopeNoPanic::get_byte_to_utf16_idx(&r, 101));
+        assert_eq!(Some(95), RopeNoPanic::get_byte_to_utf16_idx(&r, 102));
+        assert_eq!(Some(97), RopeNoPanic::get_byte_to_utf16_idx(&r, 105));
+
+        assert_eq!(Some(111), RopeNoPanic::get_byte_to_utf16_idx(&r, 143));
+
+        assert_eq!(None, RopeNoPanic::get_byte_to_utf16_idx(&r, 144));
     }
 
     #[cfg(feature = "metric_utf16")]

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -852,6 +852,15 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize> {
         self.get_utf16_to_byte_idx_impl(utf16_idx)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize> {
+        self.get_byte_to_line_idx_impl(byte_idx, line_type)
+    }
 }
 
 //==============================================================
@@ -1574,6 +1583,103 @@ mod tests {
     fn byte_to_line_idx_05() {
         let r = Rope::from_str(TEXT_LINES);
         r.byte_to_line_idx(125, LineType::Unicode);
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    #[test]
+    fn get_byte_to_line_idx_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        let byte_to_line_idxs = &[
+            [0, 0],
+            [1, 0],
+            [31, 0],
+            [32, 1],
+            [33, 1],
+            [58, 1],
+            [59, 2],
+            [60, 2],
+            [87, 2],
+            [88, 3],
+            [89, 3],
+            [124, 3],
+        ];
+        for [b, l] in byte_to_line_idxs.iter().copied() {
+            #[cfg(feature = "metric_lines_lf")]
+            assert_eq!(
+                Some(l),
+                RopeNoPanic::get_byte_to_line_idx(&r, b, LineType::LF)
+            );
+            #[cfg(feature = "metric_lines_lf_cr")]
+            assert_eq!(
+                Some(l),
+                RopeNoPanic::get_byte_to_line_idx(&r, b, LineType::LF_CR)
+            );
+            #[cfg(feature = "metric_lines_unicode")]
+            assert_eq!(
+                Some(l),
+                RopeNoPanic::get_byte_to_line_idx(&r, b, LineType::Unicode)
+            );
+        }
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    #[test]
+    fn get_byte_to_line_idx_02() {
+        let r = Rope::from_str("");
+
+        #[cfg(feature = "metric_lines_lf")]
+        assert_eq!(
+            Some(0),
+            RopeNoPanic::get_byte_to_line_idx(&r, 0, LineType::LF)
+        );
+        #[cfg(feature = "metric_lines_lf_cr")]
+        assert_eq!(
+            Some(0),
+            RopeNoPanic::get_byte_to_line_idx(&r, 0, LineType::LF_CR)
+        );
+        #[cfg(feature = "metric_lines_unicode")]
+        assert_eq!(
+            Some(0),
+            RopeNoPanic::get_byte_to_line_idx(&r, 0, LineType::Unicode)
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf")]
+    #[test]
+    fn get_byte_to_line_idx_03() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(
+            RopeNoPanic::get_byte_to_line_idx(&r, 125, LineType::LF),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_04() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(
+            RopeNoPanic::get_byte_to_line_idx(&r, 125, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_unicode")]
+    #[test]
+    fn get_byte_to_line_idx_05() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(
+            RopeNoPanic::get_byte_to_line_idx(&r, 125, LineType::Unicode),
+            None
+        );
     }
 
     #[cfg(any(

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -861,6 +861,15 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize> {
         self.get_byte_to_line_idx_impl(byte_idx, line_type)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize> {
+        self.get_line_to_byte_idx_impl(line_idx, line_type)
+    }
 }
 
 //==============================================================
@@ -1748,6 +1757,104 @@ mod tests {
     fn line_to_byte_idx_05() {
         let r = Rope::from_str(TEXT_LINES);
         r.line_to_byte_idx(5, LineType::Unicode);
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    #[test]
+    fn get_line_to_byte_idx_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        let byte_to_line_idxs = &[[0, 0], [32, 1], [59, 2], [88, 3], [124, 4]];
+        for [b, l] in byte_to_line_idxs.iter().copied() {
+            #[cfg(feature = "metric_lines_lf")]
+            assert_eq!(
+                Some(b),
+                RopeNoPanic::get_line_to_byte_idx(&r, l, LineType::LF)
+            );
+            #[cfg(feature = "metric_lines_lf_cr")]
+            assert_eq!(
+                Some(b),
+                RopeNoPanic::get_line_to_byte_idx(&r, l, LineType::LF_CR)
+            );
+            #[cfg(feature = "metric_lines_unicode")]
+            assert_eq!(
+                Some(b),
+                RopeNoPanic::get_line_to_byte_idx(&r, l, LineType::Unicode)
+            );
+        }
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    #[test]
+    fn get_line_to_byte_idx_02() {
+        let r = Rope::from_str("");
+        #[cfg(feature = "metric_lines_lf")]
+        {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 0, LineType::LF)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 1, LineType::LF)
+            );
+        }
+        #[cfg(feature = "metric_lines_lf_cr")]
+        {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 0, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 1, LineType::LF_CR)
+            );
+        }
+        #[cfg(feature = "metric_lines_unicode")]
+        {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 0, LineType::Unicode)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&r, 1, LineType::Unicode)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf")]
+    #[test]
+    fn get_line_to_byte_idx_03() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(RopeNoPanic::get_line_to_byte_idx(&r, 5, LineType::LF), None);
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_04() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&r, 5, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_unicode")]
+    #[test]
+    fn get_line_to_byte_idx_05() {
+        let r = Rope::from_str(TEXT_LINES);
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&r, 5, LineType::Unicode),
+            None
+        );
     }
 
     #[test]

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -874,6 +874,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_bytes_at(&'current self, byte_idx: usize) -> Result<Bytes<'current>> {
         self.get_bytes_at_impl(byte_idx)
     }
+
+    fn get_chars_at(&'current self, byte_idx: usize) -> Result<Chars<'current>> {
+        self.get_chars_at_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -621,7 +621,7 @@ impl Rope {
     /// On failure this leaves the rope untouched and returns the cause of the
     /// failure.
     #[inline]
-    pub fn try_insert_char(&mut self, byte_idx: usize, ch: char) -> Result<()> {
+    fn try_insert_char_impl(&mut self, byte_idx: usize, ch: char) -> Result<()> {
         let mut buf = [0u8; 4];
         self.try_insert(byte_idx, ch.encode_utf8(&mut buf))
     }
@@ -918,6 +918,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
 impl RopeNoPanicMut for Rope {
     fn try_insert(&mut self, byte_idx: usize, text: &str) -> crate::Result<()> {
         self.try_insert_impl(byte_idx, text)
+    }
+
+    fn try_insert_char(&mut self, byte_idx: usize, ch: char) -> crate::Result<()> {
+        self.try_insert_char_impl(byte_idx, ch)
     }
 }
 

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -882,6 +882,19 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_char_indices_at(&'current self, byte_idx: usize) -> Result<CharIndices<'current>> {
         self.get_char_indices_at_impl(byte_idx)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_lines_at(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> Result<Lines<'current>> {
+        self.get_lines_at_impl(line_idx, line_type)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -795,13 +795,26 @@ impl Rope {
     }
 }
 
-impl RopeNoPanic for Rope {
+impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_byte(&self, byte_idx: usize) -> Option<u8> {
         self.get_byte_impl(byte_idx)
     }
 
     fn get_char(&self, byte_idx: usize) -> Result<char> {
         self.get_char_impl(byte_idx)
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> Option<RopeSlice<'current>> {
+        self.get_line_impl(line_idx, line_type)
     }
 }
 

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -631,7 +631,7 @@ impl Rope {
     /// On failure this leaves the rope untouched and returns the cause of the
     /// failure.
     #[inline]
-    pub fn try_remove<R>(&mut self, byte_range: R) -> Result<()>
+    fn try_remove_impl<R>(&mut self, byte_range: R) -> Result<()>
     where
         R: RangeBounds<usize>,
     {
@@ -922,6 +922,13 @@ impl RopeNoPanicMut for Rope {
 
     fn try_insert_char(&mut self, byte_idx: usize, ch: char) -> crate::Result<()> {
         self.try_insert_char_impl(byte_idx, ch)
+    }
+
+    fn try_remove<R>(&mut self, byte_range: R) -> crate::Result<()>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.try_remove_impl(byte_range)
     }
 }
 
@@ -1556,6 +1563,119 @@ mod tests {
         let mut rope = Rope::from_str(TEXT);
         // Invalid range.
         rope.remove(42..21);
+    }
+
+    #[test]
+    fn try_remove_01() {
+        let mut rope = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_remove(&mut rope, 0..4).expect("`try_remove` should not fail");
+        RopeNoPanicMut::try_remove(&mut rope, 5..7).expect("`try_remove` should not fail");
+        RopeNoPanicMut::try_remove(&mut rope, 28..37).expect("`try_remove` should not fail");
+        RopeNoPanicMut::try_remove(&mut rope, 35..109).expect("`try_remove` should not fail");
+
+        assert_eq!(rope, "o the!  How're you doing?  Ie day, ！");
+    }
+
+    #[test]
+    fn try_remove_02() {
+        let mut rope = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_remove(&mut rope, ..42).expect("`try_remove` should not fail");
+
+        assert_eq!(
+            rope,
+            "ne day, isn't it?  Aren't you glad we're \
+             alive?  こんにちは、みんなさん！"
+        );
+    }
+
+    #[test]
+    fn try_remove_03() {
+        let mut rope = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_remove(&mut rope, 42..).expect("`try_remove` should not fail");
+
+        assert_eq!(rope, "Hello there!  How're you doing?  It's a fi");
+    }
+
+    #[test]
+    fn try_remove_04() {
+        let mut rope = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_remove(&mut rope, ..).expect("`try_remove` should not fail");
+
+        assert_eq!(rope, "");
+    }
+
+    #[test]
+    fn try_remove_05() {
+        let mut rope = Rope::from_str(TEXT);
+        RopeNoPanicMut::try_remove(&mut rope, 42..42).expect("`try_remove` should not fail");
+
+        assert_eq!(rope, TEXT);
+    }
+
+    #[test]
+    fn try_remove_06() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 42..128),
+            Err(crate::Error::OutOfBounds)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
+    }
+
+    #[test]
+    fn try_remove_07() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 128..128),
+            Err(crate::Error::OutOfBounds)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
+    }
+
+    #[test]
+    fn try_remove_08() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 42..126),
+            Err(crate::Error::NonCharBoundary)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
+    }
+
+    #[test]
+    fn try_remove_09() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 126..127),
+            Err(crate::Error::NonCharBoundary)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
+    }
+
+    #[test]
+    fn try_remove_10() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 126..126),
+            Err(crate::Error::NonCharBoundary)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
+    }
+
+    #[test]
+    fn try_remove_11() {
+        let mut rope = Rope::from_str(TEXT);
+        assert_eq!(
+            RopeNoPanicMut::try_remove(&mut rope, 42..21),
+            Err(crate::Error::InvalidRange)
+        );
+        // Rope did not change
+        assert_eq!(TEXT, rope);
     }
 
     // Removal failure should be atomic: either it fails with no modification,

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -878,6 +878,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_chars_at(&'current self, byte_idx: usize) -> Result<Chars<'current>> {
         self.get_chars_at_impl(byte_idx)
     }
+
+    fn get_char_indices_at(&'current self, byte_idx: usize) -> Result<CharIndices<'current>> {
+        self.get_char_indices_at_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -816,6 +816,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     ) -> Option<RopeSlice<'current>> {
         self.get_line_impl(line_idx, line_type)
     }
+
+    fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'current str, usize)> {
+        self.get_chunk_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -820,6 +820,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'current str, usize)> {
         self.get_chunk_impl(byte_idx)
     }
+
+    fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool> {
+        self.get_is_char_boundary_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -828,6 +828,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize> {
         self.get_floor_char_boundary_impl(byte_idx)
     }
+
+    fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize> {
+        self.get_ceil_char_boundary_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -824,6 +824,10 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool> {
         self.get_is_char_boundary_impl(byte_idx)
     }
+
+    fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize> {
+        self.get_floor_char_boundary_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -799,6 +799,10 @@ impl RopeNoPanic for Rope {
     fn get_byte(&self, byte_idx: usize) -> Option<u8> {
         self.get_byte_impl(byte_idx)
     }
+
+    fn get_char(&self, byte_idx: usize) -> Result<char> {
+        self.get_char_impl(byte_idx)
+    }
 }
 
 //==============================================================

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -685,7 +685,7 @@ impl Rope {
     ///
     /// On failure this returns the cause of the failure.
     #[inline]
-    pub fn try_slice<R>(&self, byte_range: R) -> Result<RopeSlice<'_>>
+    fn try_slice_impl<R>(&self, byte_range: R) -> Result<RopeSlice<'_>>
     where
         R: RangeBounds<usize>,
     {
@@ -905,6 +905,13 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
         byte_idx: usize,
     ) -> crate::Result<ChunkCursor<'current>> {
         self.get_chunk_cursor_at_impl(byte_idx)
+    }
+
+    fn try_slice<R>(&'current self, byte_range: R) -> crate::Result<RopeSlice<'current>>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.try_slice_impl(byte_range)
     }
 }
 

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
+use crate::extra::RopeNoPanic;
 use crate::{
     end_bound_to_num,
     extra::esoterica,
@@ -791,6 +792,12 @@ impl Rope {
             // chunk as the CR.
             self.insert_core_impl(byte_idx, "\n", true).unwrap();
         }
+    }
+}
+
+impl RopeNoPanic for Rope {
+    fn get_byte(&self, byte_idx: usize) -> Option<u8> {
+        self.get_byte_impl(byte_idx)
     }
 }
 

--- a/src/rope.rs
+++ b/src/rope.rs
@@ -847,6 +847,11 @@ impl<'current> RopeNoPanic<'current, 'current> for Rope {
     fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize> {
         self.get_byte_to_utf16_idx_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_utf16")]
+    fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize> {
+        self.get_utf16_to_byte_idx_impl(utf16_idx)
+    }
 }
 
 //==============================================================
@@ -1472,6 +1477,30 @@ mod tests {
         assert_eq!(105, r.utf16_to_byte_idx(97));
 
         assert_eq!(143, r.utf16_to_byte_idx(111));
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_01() {
+        let r = Rope::from_str(TEXT_EMOJI);
+
+        assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&r, 0));
+
+        assert_eq!(Some(12), RopeNoPanic::get_utf16_to_byte_idx(&r, 12));
+        assert_eq!(Some(16), RopeNoPanic::get_utf16_to_byte_idx(&r, 14));
+
+        assert_eq!(Some(35), RopeNoPanic::get_utf16_to_byte_idx(&r, 33));
+        assert_eq!(Some(39), RopeNoPanic::get_utf16_to_byte_idx(&r, 35));
+
+        assert_eq!(Some(67), RopeNoPanic::get_utf16_to_byte_idx(&r, 63));
+        assert_eq!(Some(71), RopeNoPanic::get_utf16_to_byte_idx(&r, 65));
+
+        assert_eq!(Some(101), RopeNoPanic::get_utf16_to_byte_idx(&r, 95));
+        assert_eq!(Some(105), RopeNoPanic::get_utf16_to_byte_idx(&r, 97));
+
+        assert_eq!(Some(143), RopeNoPanic::get_utf16_to_byte_idx(&r, 111));
+
+        assert_eq!(None, RopeNoPanic::get_utf16_to_byte_idx(&r, 112));
     }
 
     #[cfg(any(

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -380,17 +380,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn utf16_to_byte_idx(&self, utf16_idx: usize) -> usize {
-            assert!(utf16_idx <= self.len_utf16(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return str_indices::utf16::to_byte_idx(text, utf16_idx);
-            }
-
-            if self.get_full_info().is_some() {
-                self._utf16_to_byte_idx(utf16_idx)
-            } else {
-                let utf16_start_idx = self._byte_to_utf16_idx(self.get_byte_range()[0]);
-                self._utf16_to_byte_idx(utf16_start_idx + utf16_idx) - self.get_byte_range()[0]
+            match self.get_utf16_to_byte_idx(utf16_idx) {
+                Some(byte_idx) => byte_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1161,6 +1153,29 @@ macro_rules! shared_no_panic_impl_methods {
             } else {
                 Some(self._byte_to_utf16_idx(self.get_byte_range()[0] + byte_idx)
                     - self._byte_to_utf16_idx(self.get_byte_range()[0]))
+            }
+        }
+
+        /// Non-panicking version of `utf16_to_byte_idx`.
+        ///
+        /// If `utf16_idx` is out of bounds, returns `None`.
+        #[cfg(feature = "metric_utf16")]
+        #[track_caller]
+        #[inline]
+        fn get_utf16_to_byte_idx_impl(&self, utf16_idx: usize) -> Option<usize> {
+            if utf16_idx > self.len_utf16() {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(str_indices::utf16::to_byte_idx(text, utf16_idx));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._utf16_to_byte_idx(utf16_idx))
+            } else {
+                let utf16_start_idx = self._byte_to_utf16_idx(self.get_byte_range()[0]);
+                Some(self._utf16_to_byte_idx(utf16_start_idx + utf16_idx) - self.get_byte_range()[0])
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -1021,20 +1021,12 @@ macro_rules! shared_no_panic_impl_methods {
         /// Non-panicking version of `line()`.
         ///
         /// If `line_idx` is out of bounds, returns `None`.
-        #[cfg_attr(
-            docsrs,
-            doc(cfg(any(
-                feature = "metric_lines_lf",
-                feature = "metric_lines_lf_cr",
-                feature = "metric_lines_unicode"
-            )))
-        )]
         #[cfg(any(
             feature = "metric_lines_lf",
             feature = "metric_lines_lf_cr",
             feature = "metric_lines_unicode"
         ))]
-        pub fn get_line(&self, line_idx: usize, line_type: LineType) -> Option<RopeSlice<$rlt>> {
+        fn get_line_impl(&self, line_idx: usize, line_type: LineType) -> Option<RopeSlice<$rlt>> {
             if line_idx >= self.len_lines(line_type) {
                 return None;
             }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -417,30 +417,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> usize {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            // This becomes a corner case when an empty slice splits a CRLF pair
-            // in the source rope, so we just always handle it specially here.
-            if self.len() == 0 {
-                return 0;
-            }
-
-            if let Some(text) = self.get_str_text() {
-                return crate::str_utils::lines::from_byte_idx(text, byte_idx, line_type);
-            }
-
-            if self.get_full_info().is_some() {
-                self._byte_to_line_idx(byte_idx, line_type)
-            } else {
-                let crlf_split = if (byte_idx + self.get_byte_range()[0]) == self.get_byte_range()[1] {
-                    self._is_relevant_crlf_split(self.get_byte_range()[1], line_type)
-                } else {
-                    false
-                };
-
-                self._byte_to_line_idx(self.get_byte_range()[0] + byte_idx, line_type)
-                    - self._byte_to_line_idx(self.get_byte_range()[0], line_type)
-                    + crlf_split as usize
+            match self.get_byte_to_line_idx(byte_idx, line_type) {
+                Some(line_idx) => line_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1176,6 +1155,47 @@ macro_rules! shared_no_panic_impl_methods {
             } else {
                 let utf16_start_idx = self._byte_to_utf16_idx(self.get_byte_range()[0]);
                 Some(self._utf16_to_byte_idx(utf16_start_idx + utf16_idx) - self.get_byte_range()[0])
+            }
+        }
+
+        /// Non-panicking version of `byte_to_line_idx`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        #[cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        ))]
+        #[track_caller]
+        #[inline]
+        fn get_byte_to_line_idx_impl(&self, byte_idx: usize, line_type: LineType) -> Option<usize> {
+            if byte_idx > self.len() {
+                return None;
+            }
+
+            // This becomes a corner case when an empty slice splits a CRLF pair
+            // in the source rope, so we just always handle it specially here.
+            if self.len() == 0 {
+                return Some(0);
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(crate::str_utils::lines::from_byte_idx(text, byte_idx, line_type));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._byte_to_line_idx(byte_idx, line_type))
+            } else {
+                let crlf_split =
+                    if (byte_idx + self.get_byte_range()[0]) == self.get_byte_range()[1] {
+                        self._is_relevant_crlf_split(self.get_byte_range()[1], line_type)
+                    } else {
+                        false
+                    };
+
+                Some(self._byte_to_line_idx(self.get_byte_range()[0] + byte_idx, line_type)
+                    - self._byte_to_line_idx(self.get_byte_range()[0], line_type)
+                    + crlf_split as usize)
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -644,19 +644,7 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn lines_at(&self, line_idx: usize, line_type: LineType) -> Lines<$rlt> {
-            let result = if let Some(text) = self.get_str_text() {
-                Lines::from_str(text, line_idx, line_type)
-            } else {
-                Lines::new(
-                    self.get_root(),
-                    self.get_root_info(),
-                    self.get_byte_range(),
-                    line_idx,
-                    line_type,
-                )
-            };
-
-            match result {
+            match self.get_lines_at(line_idx, line_type) {
                 Ok(iter) => iter,
                 Err(e) => panic!("{}", e),
             }
@@ -1248,6 +1236,30 @@ macro_rules! shared_no_panic_impl_methods {
         #[inline]
         fn get_char_indices_at_impl(&self, byte_idx: usize) -> Result<CharIndices<$rlt>> {
             self.get_chars_at(byte_idx).map(CharIndices::new)
+        }
+
+        /// Non-panicking version of `lines_at`.
+        ///
+        /// If `line_idx` is out of bounds, returns `Err`.
+        #[cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        ))]
+        #[track_caller]
+        #[inline]
+        fn get_lines_at_impl(&self, line_idx: usize, line_type: LineType) -> Result<Lines<$rlt>> {
+            if let Some(text) = self.get_str_text() {
+                Lines::from_str(text, line_idx, line_type)
+            } else {
+                Lines::new(
+                    self.get_root(),
+                    self.get_root_info(),
+                    self.get_byte_range(),
+                    line_idx,
+                    line_type,
+                )
+            }
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -148,14 +148,10 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn ceil_char_boundary(&self, byte_idx: usize) -> usize {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return crate::ceil_char_boundary(byte_idx, text.as_bytes());
+            match self.get_ceil_char_boundary(byte_idx) {
+                Some(boundary) => boundary,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
-
-            let (text, offset) = self.chunk(byte_idx);
-            offset + crate::ceil_char_boundary(byte_idx - offset, text.as_bytes())
         }
 
         /// If the text ends with a line break, returns its byte index.
@@ -1102,6 +1098,24 @@ macro_rules! shared_no_panic_impl_methods {
 
             let (text, offset) = self.chunk(byte_idx);
             Some(offset + crate::floor_char_boundary(byte_idx - offset, text.as_bytes()))
+        }
+
+        /// Non-panicking version of `ceil_char_boundary()`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        #[track_caller]
+        #[inline]
+        fn get_ceil_char_boundary_impl(&self, byte_idx: usize) -> Option<usize> {
+            if byte_idx > self.len() {
+               return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(crate::ceil_char_boundary(byte_idx, text.as_bytes()));
+            }
+
+            let (text, offset) = self.chunk(byte_idx);
+            Some(offset + crate::ceil_char_boundary(byte_idx - offset, text.as_bytes()))
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -983,7 +983,7 @@ macro_rules! shared_no_panic_impl_methods {
         /// Non-panicking version of `byte()`.
         ///
         /// If `byte_idx` is out of bounds, returns `None`.
-        pub fn get_byte(&self, byte_idx: usize) -> Option<u8> {
+        fn get_byte_impl(&self, byte_idx: usize) -> Option<u8> {
             if byte_idx >= self.len() {
                 return None;
             }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -574,7 +574,10 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn char_indices_at(&self, byte_idx: usize) -> CharIndices<$rlt> {
-            CharIndices::new(self.chars_at(byte_idx))
+            match self.get_char_indices_at(byte_idx) {
+                Ok(iter) => iter,
+                Err(e) => panic!("{}", e),
+            }
         }
 
         /// Creates an iterator over the lines of the `Rope`.
@@ -1233,6 +1236,18 @@ macro_rules! shared_no_panic_impl_methods {
                     self.get_byte_range()[0] + byte_idx,
                 )
             }
+        }
+
+        /// Non-panicking version of `char_indices_at`.
+        ///
+        /// Returns `Err` if:
+        ///
+        /// - `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
+        /// - `byte_idx` is not a char boundary.
+        #[track_caller]
+        #[inline]
+        fn get_char_indices_at_impl(&self, byte_idx: usize) -> Result<CharIndices<$rlt>> {
+            self.get_chars_at(byte_idx).map(CharIndices::new)
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -304,17 +304,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn byte_to_char_idx(&self, byte_idx: usize) -> usize {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return str_indices::chars::from_byte_idx(text, byte_idx);
-            }
-
-            if self.get_full_info().is_some() {
-                self._byte_to_char_idx(byte_idx)
-            } else {
-                self._byte_to_char_idx(self.get_byte_range()[0] + byte_idx)
-                    - self._byte_to_char_idx(self.get_byte_range()[0])
+            match self.get_byte_to_char_idx(byte_idx) {
+                Some(char_idx) => char_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1116,6 +1108,29 @@ macro_rules! shared_no_panic_impl_methods {
 
             let (text, offset) = self.chunk(byte_idx);
             Some(offset + crate::ceil_char_boundary(byte_idx - offset, text.as_bytes()))
+        }
+
+        /// Non-panicking version of `byte_to_char_idx`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        #[cfg(feature = "metric_chars")]
+        #[track_caller]
+        #[inline]
+        fn get_byte_to_char_idx_impl(&self, byte_idx: usize) -> Option<usize> {
+            if byte_idx > self.len() {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(str_indices::chars::from_byte_idx(text, byte_idx));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._byte_to_char_idx(byte_idx))
+            } else {
+                Some(self._byte_to_char_idx(self.get_byte_range()[0] + byte_idx)
+                    - self._byte_to_char_idx(self.get_byte_range()[0]))
+            }
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -493,18 +493,7 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn bytes_at(&self, byte_idx: usize) -> Bytes<$rlt> {
-            let result = if let Some(text) = self.get_str_text() {
-                Bytes::from_str(text, byte_idx)
-            } else {
-                Bytes::new(
-                    self.get_root(),
-                    self.get_root_info(),
-                    self.get_byte_range(),
-                    self.get_byte_range()[0] + byte_idx,
-                )
-            };
-
-            match result {
+            match self.get_bytes_at(byte_idx) {
                 Ok(iter) => iter,
                 Err(e) => panic!("{}", e),
             }
@@ -1215,6 +1204,24 @@ macro_rules! shared_no_panic_impl_methods {
                 Some(self._line_to_byte_idx(line_start_idx + line_idx, line_type)
                     .saturating_sub(self.get_byte_range()[0])
                     .min(self.len()))
+            }
+        }
+
+        /// Non-panicking version of `bytes_at`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `Err`.
+        #[track_caller]
+        #[inline]
+        fn get_bytes_at_impl(&self, byte_idx: usize) -> Result<Bytes<$rlt>> {
+            if let Some(text) = self.get_str_text() {
+                Bytes::from_str(text, byte_idx)
+            } else {
+                Bytes::new(
+                    self.get_root(),
+                    self.get_root_info(),
+                    self.get_byte_range(),
+                    self.get_byte_range()[0] + byte_idx,
+                )
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -453,19 +453,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> usize {
-            assert!(line_idx <= self.len_lines(line_type), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return crate::str_utils::lines::to_byte_idx(text, line_idx, line_type);
-            }
-
-            if self.get_full_info().is_some() {
-                self._line_to_byte_idx(line_idx, line_type)
-            } else {
-                let line_start_idx = self._byte_to_line_idx(self.get_byte_range()[0], line_type);
-                self._line_to_byte_idx(line_start_idx + line_idx, line_type)
-                    .saturating_sub(self.get_byte_range()[0])
-                    .min(self.len())
+            match self.get_line_to_byte_idx(line_idx, line_type) {
+                Some(byte_idx) => byte_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1196,6 +1186,35 @@ macro_rules! shared_no_panic_impl_methods {
                 Some(self._byte_to_line_idx(self.get_byte_range()[0] + byte_idx, line_type)
                     - self._byte_to_line_idx(self.get_byte_range()[0], line_type)
                     + crlf_split as usize)
+            }
+        }
+
+        /// Non-panicking version of `line_to_byte_idx`.
+        ///
+        /// If `line_idx` is out of bounds, returns `None`.
+        #[cfg(any(
+            feature = "metric_lines_lf",
+            feature = "metric_lines_lf_cr",
+            feature = "metric_lines_unicode"
+        ))]
+        #[track_caller]
+        #[inline]
+        fn get_line_to_byte_idx_impl(&self, line_idx: usize, line_type: LineType) -> Option<usize> {
+            if line_idx > self.len_lines(line_type) {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(crate::str_utils::lines::to_byte_idx(text, line_idx, line_type));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._line_to_byte_idx(line_idx, line_type))
+            } else {
+                let line_start_idx = self._byte_to_line_idx(self.get_byte_range()[0], line_type);
+                Some(self._line_to_byte_idx(line_start_idx + line_idx, line_type)
+                    .saturating_sub(self.get_byte_range()[0])
+                    .min(self.len()))
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -327,17 +327,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn char_to_byte_idx(&self, char_idx: usize) -> usize {
-            assert!(char_idx <= self.len_chars(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return str_indices::chars::to_byte_idx(text, char_idx);
-            }
-
-            if self.get_full_info().is_some() {
-                self._char_to_byte_idx(char_idx)
-            } else {
-                let char_start_idx = self._byte_to_char_idx(self.get_byte_range()[0]);
-                self._char_to_byte_idx(char_start_idx + char_idx) - self.get_byte_range()[0]
+            match self.get_char_to_byte_idx(char_idx) {
+                Some(byte_idx) => byte_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1130,6 +1122,29 @@ macro_rules! shared_no_panic_impl_methods {
             } else {
                 Some(self._byte_to_char_idx(self.get_byte_range()[0] + byte_idx)
                     - self._byte_to_char_idx(self.get_byte_range()[0]))
+            }
+        }
+
+         /// Non-panicking version of `char_to_byte_idx`.
+        ///
+        /// If `char_idx` is out of bounds, returns `None`.
+        #[cfg(feature = "metric_chars")]
+        #[track_caller]
+        #[inline]
+        fn get_char_to_byte_idx_impl(&self, char_idx: usize) -> Option<usize> {
+            if char_idx > self.len_chars() {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(str_indices::chars::to_byte_idx(text, char_idx));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._char_to_byte_idx(char_idx))
+            } else {
+                let char_start_idx = self._byte_to_char_idx(self.get_byte_range()[0]);
+                Some(self._char_to_byte_idx(char_start_idx + char_idx) - self.get_byte_range()[0])
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -685,19 +685,8 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn chunks_at(&self, byte_idx: usize) -> (Chunks<$rlt>, usize) {
-            let result = if let Some(text) = self.get_str_text() {
-                Chunks::from_str(text, byte_idx)
-            } else {
-                Chunks::new(
-                    self.get_root(),
-                    self.get_root_info(),
-                    self.get_byte_range(),
-                    self.get_byte_range()[0] + byte_idx,
-                )
-            };
-
-            match result {
-                Ok((chunks, start_idx)) => (chunks, start_idx.saturating_sub(self.get_byte_range()[0])),
+             match self.get_chunks_at(byte_idx) {
+                Ok(chunks) => chunks,
                 Err(e) => panic!("{}", e),
             }
         }
@@ -1260,6 +1249,28 @@ macro_rules! shared_no_panic_impl_methods {
                     line_type,
                 )
             }
+        }
+
+        /// Non-panicking version of `chunks_at`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `Err`.
+        #[track_caller]
+        #[inline]
+        fn get_chunks_at_impl(&self, byte_idx: usize) -> Result<(Chunks<$rlt>, usize)> {
+            let result = if let Some(text) = self.get_str_text() {
+                Chunks::from_str(text, byte_idx)
+            } else {
+                Chunks::new(
+                    self.get_root(),
+                    self.get_root_info(),
+                    self.get_byte_range(),
+                    self.get_byte_range()[0] + byte_idx,
+                )
+            };
+
+            result.map(|(chunks, start_idx)| {
+                (chunks, start_idx.saturating_sub(self.get_byte_range()[0]))
+            })
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -724,18 +724,7 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn chunk_cursor_at(&self, byte_idx: usize) -> ChunkCursor<$rlt> {
-            let result = if let Some(text) = self.get_str_text() {
-                ChunkCursor::from_str(text, byte_idx)
-            } else {
-                ChunkCursor::new(
-                    self.get_root(),
-                    self.get_root_info(),
-                    self.get_byte_range(),
-                    self.get_byte_range()[0] + byte_idx,
-                )
-            };
-
-            match result {
+            match self.get_chunk_cursor_at(byte_idx) {
                 Ok(cursor) => cursor,
                 Err(e) => panic!("{}", e),
             }
@@ -1271,6 +1260,24 @@ macro_rules! shared_no_panic_impl_methods {
             result.map(|(chunks, start_idx)| {
                 (chunks, start_idx.saturating_sub(self.get_byte_range()[0]))
             })
+        }
+
+        /// Non-panicking version of `chunk_cursor_at`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `Err`.
+        #[track_caller]
+        #[inline]
+        fn get_chunk_cursor_at_impl(&self, byte_idx: usize) -> Result<ChunkCursor<$rlt>> {
+            if let Some(text) = self.get_str_text() {
+                ChunkCursor::from_str(text, byte_idx)
+            } else {
+                ChunkCursor::new(
+                    self.get_root(),
+                    self.get_root_info(),
+                    self.get_byte_range(),
+                    self.get_byte_range()[0] + byte_idx,
+                )
+            }
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -353,17 +353,9 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn byte_to_utf16_idx(&self, byte_idx: usize) -> usize {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return str_indices::utf16::from_byte_idx(text, byte_idx);
-            }
-
-            if self.get_full_info().is_some() {
-                self._byte_to_utf16_idx(byte_idx)
-            } else {
-                self._byte_to_utf16_idx(self.get_byte_range()[0] + byte_idx)
-                    - self._byte_to_utf16_idx(self.get_byte_range()[0])
+            match self.get_byte_to_utf16_idx(byte_idx) {
+                Some(utf16_idx) => utf16_idx,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
         }
 
@@ -1145,6 +1137,30 @@ macro_rules! shared_no_panic_impl_methods {
             } else {
                 let char_start_idx = self._byte_to_char_idx(self.get_byte_range()[0]);
                 Some(self._char_to_byte_idx(char_start_idx + char_idx) - self.get_byte_range()[0])
+            }
+        }
+
+
+        /// Non-panicking version of `byte_to_utf16_idx`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        #[cfg(feature = "metric_utf16")]
+        #[track_caller]
+        #[inline]
+        fn get_byte_to_utf16_idx_impl(&self, byte_idx: usize) -> Option<usize> {
+            if byte_idx > self.len() {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(str_indices::utf16::from_byte_idx(text, byte_idx));
+            }
+
+            if self.get_full_info().is_some() {
+                Some(self._byte_to_utf16_idx(byte_idx))
+            } else {
+                Some(self._byte_to_utf16_idx(self.get_byte_range()[0] + byte_idx)
+                    - self._byte_to_utf16_idx(self.get_byte_range()[0]))
             }
         }
     };

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -131,14 +131,10 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn floor_char_boundary(&self, byte_idx: usize) -> usize {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return crate::floor_char_boundary(byte_idx, text.as_bytes());
+            match self.get_floor_char_boundary(byte_idx) {
+                Some(boundary) => boundary,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
-
-            let (text, offset) = self.chunk(byte_idx);
-            offset + crate::floor_char_boundary(byte_idx - offset, text.as_bytes())
         }
 
         /// Returns the byte index of the closest char boundary greater than or
@@ -1088,6 +1084,24 @@ macro_rules! shared_no_panic_impl_methods {
 
             let (text, offset) = self.chunk(byte_idx);
             Some(crate::is_char_boundary(byte_idx - offset, text.as_bytes()))
+        }
+
+        /// Non-panicking version of `floor_char_boundary()`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        #[track_caller]
+        #[inline]
+        fn get_floor_char_boundary_impl(&self, byte_idx: usize) -> Option<usize> {
+            if byte_idx > self.len() {
+               return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(crate::floor_char_boundary(byte_idx, text.as_bytes()));
+            }
+
+            let (text, offset) = self.chunk(byte_idx);
+            Some(offset + crate::floor_char_boundary(byte_idx - offset, text.as_bytes()))
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -114,14 +114,10 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn is_char_boundary(&self, byte_idx: usize) -> bool {
-            assert!(byte_idx <= self.len(), "{}", crate::Error::OutOfBounds);
-
-            if let Some(text) = self.get_str_text() {
-                return text.is_char_boundary(byte_idx);
+            match self.get_is_char_boundary(byte_idx) {
+                Some(is_boundary) => is_boundary,
+                None => panic!("{}", crate::Error::OutOfBounds),
             }
-
-            let (text, offset) = self.chunk(byte_idx);
-            crate::is_char_boundary(byte_idx - offset, text.as_bytes())
         }
 
         /// Returns the byte index of the closest char boundary less than or
@@ -1076,6 +1072,22 @@ macro_rules! shared_no_panic_impl_methods {
 
                 Some((trimmed_chunk, local_start_byte))
             }
+        }
+
+        /// Non-panicking version of `is_char_boundary()`.
+        ///
+        /// If `byte_idx` is out of bounds, returns `None`.
+        fn get_is_char_boundary_impl(&self, byte_idx: usize) -> Option<bool> {
+            if byte_idx > self.len() {
+                return None;
+            }
+
+            if let Some(text) = self.get_str_text() {
+                return Some(text.is_char_boundary(byte_idx));
+            }
+
+            let (text, offset) = self.chunk(byte_idx);
+            Some(crate::is_char_boundary(byte_idx - offset, text.as_bytes()))
         }
     };
 }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -533,18 +533,7 @@ macro_rules! shared_main_impl_methods {
         #[track_caller]
         #[inline]
         pub fn chars_at(&self, byte_idx: usize) -> Chars<$rlt> {
-            let result = if let Some(text) = self.get_str_text() {
-                Chars::from_str(text, byte_idx)
-            } else {
-                Chars::new(
-                    self.get_root(),
-                    self.get_root_info(),
-                    self.get_byte_range(),
-                    self.get_byte_range()[0] + byte_idx,
-                )
-            };
-
-            match result {
+            match self.get_chars_at(byte_idx) {
                 Ok(iter) => iter,
                 Err(e) => panic!("{}", e),
             }
@@ -1217,6 +1206,27 @@ macro_rules! shared_no_panic_impl_methods {
                 Bytes::from_str(text, byte_idx)
             } else {
                 Bytes::new(
+                    self.get_root(),
+                    self.get_root_info(),
+                    self.get_byte_range(),
+                    self.get_byte_range()[0] + byte_idx,
+                )
+            }
+        }
+
+        /// Non-panicking version of `chars_at`.
+        ///
+        /// Returns `Err` if:
+        ///
+        /// - `byte_idx` is out of bounds (i.e. `byte_idx > len()`).
+        /// - `byte_idx` is not a char boundary.
+        #[track_caller]
+        #[inline]
+        fn get_chars_at_impl(&self, byte_idx: usize) -> Result<Chars<$rlt>> {
+            if let Some(text) = self.get_str_text() {
+                Chars::from_str(text, byte_idx)
+            } else {
+                Chars::new(
                     self.get_root(),
                     self.get_root_info(),
                     self.get_byte_range(),

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -1000,7 +1000,7 @@ macro_rules! shared_no_panic_impl_methods {
         /// - Out of bounds.
         ///
         /// On failure returns the cause of failure.
-        pub fn get_char(&self, byte_idx: usize) -> Result<char> {
+        fn get_char_impl(&self, byte_idx: usize) -> Result<char> {
             if byte_idx >= self.len() {
                 return Err(OutOfBounds);
             }

--- a/src/shared_impl.rs
+++ b/src/shared_impl.rs
@@ -1048,7 +1048,7 @@ macro_rules! shared_no_panic_impl_methods {
         /// Non-panicking version of `chunk()`.
         ///
         /// If `byte_idx` is out of bounds, returns `None`.
-        pub fn get_chunk(&self, byte_idx: usize) -> Option<(&$rlt str, usize)> {
+        fn get_chunk_impl(&self, byte_idx: usize) -> Option<(&$rlt str, usize)> {
             if byte_idx > self.len() {
                 return None;
             }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -217,13 +217,26 @@ impl<'a> RopeSlice<'a> {
     crate::shared_impl::shared_no_panic_impl_methods!('a);
 }
 
-impl<'a> RopeNoPanic for RopeSlice<'a> {
+impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'original> {
     fn get_byte(&self, byte_idx: usize) -> Option<u8> {
         self.get_byte_impl(byte_idx)
     }
 
     fn get_char(&self, byte_idx: usize) -> Result<char> {
         self.get_char_impl(byte_idx)
+    }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> Option<RopeSlice<'original>> {
+        self.get_line_impl(line_idx, line_type)
     }
 }
 
@@ -1337,6 +1350,171 @@ mod tests {
             assert_eq!(t.line(4, LineType::LF_CR).len_lines(LineType::LF_CR), 2);
             assert_eq!(t.line(5, LineType::LF_CR).len_lines(LineType::LF_CR), 1);
         }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 34..112) {
+            // "'s a fine day, isn't it?\nAren't you glad \
+            //  we're alive?\nこんにちは、みん"
+
+            let l0 = RopeNoPanic::get_line(&t, 0, LineType::LF_CR);
+            assert_eq!(l0, Some("'s a fine day, isn't it?\n".into()));
+            let l0 = l0.unwrap();
+            assert_eq!(l0.len(), 25);
+            assert_eq!(l0.len_lines(LineType::LF_CR), 2);
+
+            let l1 = RopeNoPanic::get_line(&t, 1, LineType::LF_CR);
+            assert_eq!(l1, Some("Aren't you glad we're alive?\n".into()));
+            let l1 = l1.unwrap();
+            assert_eq!(l1.len(), 29);
+            assert_eq!(l1.len_lines(LineType::LF_CR), 2);
+
+            let l2 = RopeNoPanic::get_line(&t, 2, LineType::LF_CR);
+            assert_eq!(l2, Some("こんにちは、みん".into()));
+            let l2 = l2.unwrap();
+            assert_eq!(l2.len(), 24);
+            assert_eq!(l2.len_lines(LineType::LF_CR), 1);
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_02() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 34..59) {
+            // "'s a fine day, isn't it?\n"
+
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 0, LineType::LF_CR),
+                Some("'s a fine day, isn't it?\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 1, LineType::LF_CR),
+                Some("".into())
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_03() {
+        let r = Rope::from_str("Hi\nHi\nHi\nHi\nHi\nHi\n");
+        for t in make_test_data(&r, "Hi\nHi\nHi\nHi\nHi\nHi\n", 1..17) {
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 0, LineType::LF_CR),
+                Some("i\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 1, LineType::LF_CR),
+                Some("Hi\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 2, LineType::LF_CR),
+                Some("Hi\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 3, LineType::LF_CR),
+                Some("Hi\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 4, LineType::LF_CR),
+                Some("Hi\n".into())
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 5, LineType::LF_CR),
+                Some("Hi".into())
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_04() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 43..43) {
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 0, LineType::LF_CR),
+                Some("".into())
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_05a() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..97);
+        assert_eq!(RopeNoPanic::get_line(&s, 3, LineType::LF_CR), None);
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_05b() {
+        let s: RopeSlice = (&TEXT_LINES[34..97]).into();
+        assert_eq!(RopeNoPanic::get_line(&s, 3, LineType::LF_CR), None);
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_06() {
+        let text = "1\n2\n3\n4\n5\n6\n7\n8";
+        let r = Rope::from_str(text);
+        for t in make_test_data(&r, text, 1..11) {
+            // "\n2\n3\n4\n5\n6"
+
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 0, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                2
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 1, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                2
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 2, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                2
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 3, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                2
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 4, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                2
+            );
+            assert_eq!(
+                RopeNoPanic::get_line(&t, 5, LineType::LF_CR)
+                    .unwrap()
+                    .len_lines(LineType::LF_CR),
+                1
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_07() {
+        // Tests lifetimes. See `reslice` test.
+        let r = Rope::from_str(TEXT_LINES);
+
+        let line = {
+            let s = r.slice(34..97);
+            RopeNoPanic::get_line(&s, 1, LineType::LF_CR).expect("`get_line` should not fail")
+        };
+        _ = line;
     }
 
     #[cfg(feature = "metric_lines_lf")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -171,7 +171,7 @@ impl<'a> RopeSlice<'a> {
     ///
     /// On failure this returns the cause of the failure.
     #[inline]
-    pub fn try_slice<R>(&self, byte_range: R) -> Result<RopeSlice<'a>>
+    fn try_slice_impl<R>(&self, byte_range: R) -> Result<RopeSlice<'a>>
     where
         R: RangeBounds<usize>,
     {
@@ -328,6 +328,13 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     ) -> crate::Result<ChunkCursor<'original>> {
         self.get_chunk_cursor_at_impl(byte_idx)
     }
+
+    fn try_slice<R>(&'current self, byte_range: R) -> crate::Result<RopeSlice<'original>>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.try_slice_impl(byte_range)
+    }
 }
 
 // Stdlib trait impls.
@@ -452,6 +459,20 @@ mod tests {
         let s = {
             let s1 = r.slice(4..32);
             s1.slice(2..24)
+        };
+        _ = s;
+    }
+
+    #[test]
+    fn try_reslice() {
+        // This is a compile-time test, to make sure that lifetimes work
+        // as expected when taking slices of slices.  The lifetime of a
+        // slice-of-a-slice should depend on the original rope, not the slice it
+        // was sliced from.
+        let r = Rope::from_str(TEXT);
+        let s = {
+            let s1 = r.try_slice(4..32).expect("`try_slice` should not fail");
+            s1.try_slice(2..24).expect("`try_slice` should not fail")
         };
         _ = s;
     }
@@ -2582,6 +2603,130 @@ mod tests {
     fn try_slice_panic_03() {
         let s: RopeSlice = ("🐸").into();
         assert_eq!(Err(crate::Error::NonCharBoundary), s.try_slice(2..));
+    }
+
+    #[test]
+    fn try_slice_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, ..) {
+            let s = RopeNoPanic::try_slice(&t, ..).expect("`try_slice` should not fail");
+
+            assert_eq!(TEXT, s);
+        }
+    }
+
+    #[test]
+    fn try_slice_02() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 50..118) {
+            let s = RopeNoPanic::try_slice(&t, 3..25).expect("`try_slice` should not fail");
+
+            assert_eq!(&TEXT[53..75], s);
+        }
+    }
+
+    #[test]
+    fn try_slice_03() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 50..118) {
+            let s = RopeNoPanic::try_slice(&t, 7..65).expect("`try_slice` should not fail");
+
+            assert_eq!(&TEXT[57..115], s);
+        }
+    }
+
+    #[test]
+    fn try_slice_04() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 50..118) {
+            let s = RopeNoPanic::try_slice(&t, 21..21).expect("`try_slice` should not fail");
+
+            assert_eq!("", s);
+        }
+    }
+
+    #[test]
+    fn try_slice_05a() {
+        let r = Rope::from_str(TEXT);
+        let s = RopeNoPanic::try_slice(&r, 50..118).expect("`try_slice` should not fail");
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 21..20), // Wrong ordering on purpose.
+            Err(crate::Error::InvalidRange)
+        ));
+    }
+
+    #[test]
+    fn try_slice_05b() {
+        let s: RopeSlice = (&TEXT[50..118]).into();
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 21..20), // Wrong ordering on purpose.
+            Err(crate::Error::InvalidRange)
+        ));
+    }
+
+    #[test]
+    fn try_slice_06a() {
+        let r = Rope::from_str(TEXT);
+        let s = RopeNoPanic::try_slice(&r, 50..85).expect("`try_slice` should not fail");
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 35..36),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn try_slice_06b() {
+        let s: RopeSlice = (&TEXT[50..85]).into();
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 35..36),
+            Err(crate::Error::OutOfBounds)
+        ));
+    }
+
+    #[test]
+    fn try_slice_07a() {
+        let r = Rope::from_str(TEXT);
+        let s = RopeNoPanic::try_slice(&r, 50..118).expect("`try_slice` should not fail");
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, ..43),
+            Err(crate::Error::NonCharBoundary)
+        ));
+    }
+
+    #[test]
+    fn try_slice_07b() {
+        let s: RopeSlice = (&TEXT[50..118]).into();
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, ..43),
+            Err(crate::Error::NonCharBoundary)
+        ));
+    }
+
+    #[test]
+    fn try_slice_08a() {
+        let r = Rope::from_str(TEXT);
+        let s = RopeNoPanic::try_slice(&r, 50..118).expect("`try_slice` should not fail");
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 43..),
+            Err(crate::Error::NonCharBoundary)
+        ));
+    }
+
+    #[test]
+    fn try_slice_08b() {
+        let s: RopeSlice = (&TEXT[50..118]).into();
+
+        assert!(matches!(
+            RopeNoPanic::try_slice(&s, 43..),
+            Err(crate::Error::NonCharBoundary)
+        ));
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -321,6 +321,13 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'original>, usize)> {
         self.get_chunks_at_impl(byte_idx)
     }
+
+    fn get_chunk_cursor_at(
+        &'current self,
+        byte_idx: usize,
+    ) -> crate::Result<ChunkCursor<'original>> {
+        self.get_chunk_cursor_at_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -480,6 +487,8 @@ mod tests {
                     .expect("`get_lines_at` should not fail"),
                 s1.get_chunks_at(1)
                     .expect("`get_chunks_at` should not fail"),
+                s1.get_chunk_cursor_at(1)
+                    .expect("`get_chunk_cursor_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -283,6 +283,15 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize> {
         self.get_byte_to_line_idx_impl(byte_idx, line_type)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize> {
+        self.get_line_to_byte_idx_impl(line_idx, line_type)
+    }
 }
 
 // Stdlib trait impls.
@@ -1396,6 +1405,96 @@ mod tests {
     fn line_to_byte_idx_04b() {
         let s: RopeSlice = (&"\n\n\n\n"[1..3]).into();
         s.line_to_byte_idx(4, LineType::LF_CR);
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 34..112) {
+            assert_eq!(
+                "'s a fine day, isn't it?\nAren't you glad \
+             we're alive?\nこんにちは、みん",
+                t,
+            );
+
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&t, 0, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(25),
+                RopeNoPanic::get_line_to_byte_idx(&t, 1, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(54),
+                RopeNoPanic::get_line_to_byte_idx(&t, 2, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(78),
+                RopeNoPanic::get_line_to_byte_idx(&t, 3, LineType::LF_CR)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_02() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 43..43) {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&t, 0, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_line_to_byte_idx(&t, 1, LineType::LF_CR)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_03a() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..97);
+
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&s, 4, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_03b() {
+        let s: RopeSlice = (&TEXT_LINES[34..97]).into();
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&s, 4, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_04a() {
+        let r = Rope::from_str("\n\n\n\n");
+        let s = r.slice(1..3);
+
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&s, 4, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_line_to_byte_idx_04b() {
+        let s: RopeSlice = (&"\n\n\n\n"[1..3]).into();
+        assert_eq!(
+            RopeNoPanic::get_line_to_byte_idx(&s, 4, LineType::LF_CR),
+            None
+        );
     }
 
     #[cfg(feature = "metric_utf16")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -292,6 +292,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_line_to_byte_idx(&self, line_idx: usize, line_type: LineType) -> Option<usize> {
         self.get_line_to_byte_idx_impl(line_idx, line_type)
     }
+
+    fn get_bytes_at(&'current self, byte_idx: usize) -> Result<Bytes<'original>> {
+        self.get_bytes_at_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -442,6 +446,7 @@ mod tests {
                 s1.chunks_at(1),
                 s1.chunk_cursor(),
                 s1.chunk_cursor_at(1),
+                s1.get_bytes_at(1).expect("`get_bytes_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -221,6 +221,10 @@ impl<'a> RopeNoPanic for RopeSlice<'a> {
     fn get_byte(&self, byte_idx: usize) -> Option<u8> {
         self.get_byte_impl(byte_idx)
     }
+
+    fn get_char(&self, byte_idx: usize) -> Result<char> {
+        self.get_char_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -1173,6 +1177,72 @@ mod tests {
     fn char_03b() {
         let s: RopeSlice = (&TEXT[43..43]).into();
         s.char(0);
+    }
+
+    #[test]
+    fn get_char_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 34..118) {
+            // t's \
+            // a fine day, isn't it?  Aren't you glad \
+            // we're alive?  こんにちは、みんな
+
+            assert_eq!(RopeNoPanic::get_char(&t, 0), Ok('t'));
+            assert_eq!(RopeNoPanic::get_char(&t, 10), Ok(' '));
+            assert_eq!(RopeNoPanic::get_char(&t, 18), Ok('n'));
+            assert_eq!(RopeNoPanic::get_char(&t, 81), Ok('な'));
+        }
+    }
+
+    #[test]
+    fn get_char_02a() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(34..118);
+        assert_eq!(
+            RopeNoPanic::get_char(&s, s.len()),
+            Err(crate::Error::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn get_char_02b() {
+        let s: RopeSlice = (&TEXT[34..118]).into();
+        assert_eq!(
+            RopeNoPanic::get_char(&s, s.len()),
+            Err(crate::Error::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn get_char_03a() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(43..43);
+        assert_eq!(RopeNoPanic::get_char(&s, 0), Err(crate::Error::OutOfBounds));
+    }
+
+    #[test]
+    fn get_char_03b() {
+        let s: RopeSlice = (&TEXT[43..43]).into();
+        assert_eq!(RopeNoPanic::get_char(&s, 0), Err(crate::Error::OutOfBounds));
+    }
+
+    #[test]
+    fn get_char_04a() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(34..118);
+        assert_eq!(
+            RopeNoPanic::get_char(&s, 82),
+            Err(crate::Error::NonCharBoundary)
+        );
+    }
+
+    #[test]
+    fn get_char_04b() {
+        let s: RopeSlice = (&TEXT[34..118]).into();
+        assert_eq!(
+            RopeNoPanic::get_char(&s, 82),
+            Err(crate::Error::NonCharBoundary)
+        );
     }
 
     #[cfg(feature = "metric_lines_lf_cr")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -250,6 +250,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize> {
         self.get_floor_char_boundary_impl(byte_idx)
     }
+
+    fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize> {
+        self.get_ceil_char_boundary_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -668,6 +672,44 @@ mod tests {
 
             assert_eq!(134, t.ceil_char_boundary(134));
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn ceil_char_boundary_02() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(3..137);
+        let _ = s.ceil_char_boundary(s.len() + 1);
+    }
+
+    #[test]
+    fn get_ceil_char_boundary_01() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, 3..137) {
+            assert_eq!(Some(0), RopeNoPanic::get_ceil_char_boundary(&t, 0));
+            assert_eq!(Some(1), RopeNoPanic::get_ceil_char_boundary(&t, 1));
+            assert_eq!(Some(2), RopeNoPanic::get_ceil_char_boundary(&t, 2));
+
+            assert_eq!(Some(9), RopeNoPanic::get_ceil_char_boundary(&t, 9));
+            assert_eq!(Some(13), RopeNoPanic::get_ceil_char_boundary(&t, 10));
+            assert_eq!(Some(13), RopeNoPanic::get_ceil_char_boundary(&t, 11));
+            assert_eq!(Some(13), RopeNoPanic::get_ceil_char_boundary(&t, 12));
+            assert_eq!(Some(13), RopeNoPanic::get_ceil_char_boundary(&t, 13));
+
+            assert_eq!(Some(104), RopeNoPanic::get_ceil_char_boundary(&t, 104));
+            assert_eq!(Some(107), RopeNoPanic::get_ceil_char_boundary(&t, 105));
+            assert_eq!(Some(107), RopeNoPanic::get_ceil_char_boundary(&t, 106));
+            assert_eq!(Some(107), RopeNoPanic::get_ceil_char_boundary(&t, 107));
+
+            assert_eq!(Some(134), RopeNoPanic::get_ceil_char_boundary(&t, 134));
+        }
+    }
+
+    #[test]
+    fn get_ceil_char_boundary_02() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(3..137);
+        assert_eq!(RopeNoPanic::get_ceil_char_boundary(&s, s.len() + 1), None);
     }
 
     #[cfg(feature = "metric_chars")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -254,6 +254,11 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_ceil_char_boundary(&self, byte_idx: usize) -> Option<usize> {
         self.get_ceil_char_boundary_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_chars")]
+    fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize> {
+        self.get_byte_to_char_idx_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -736,6 +741,49 @@ mod tests {
             assert_eq!(13, t.byte_to_char_idx(35));
             assert_eq!(14, t.byte_to_char_idx(36));
         }
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    #[should_panic]
+    fn byte_to_char_idx_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(88..124);
+        let _ = s.byte_to_char_idx(s.len() + 1);
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_byte_to_char_idx_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 88..124) {
+            assert_eq!("?  こんにちは、みんなさん", t);
+
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_char_idx(&t, 0));
+            assert_eq!(Some(1), RopeNoPanic::get_byte_to_char_idx(&t, 1));
+            assert_eq!(Some(2), RopeNoPanic::get_byte_to_char_idx(&t, 2));
+
+            assert_eq!(Some(3), RopeNoPanic::get_byte_to_char_idx(&t, 3));
+            assert_eq!(Some(3), RopeNoPanic::get_byte_to_char_idx(&t, 4));
+            assert_eq!(Some(3), RopeNoPanic::get_byte_to_char_idx(&t, 5));
+
+            assert_eq!(Some(4), RopeNoPanic::get_byte_to_char_idx(&t, 6));
+            assert_eq!(Some(4), RopeNoPanic::get_byte_to_char_idx(&t, 7));
+            assert_eq!(Some(4), RopeNoPanic::get_byte_to_char_idx(&t, 8));
+
+            assert_eq!(Some(13), RopeNoPanic::get_byte_to_char_idx(&t, 33));
+            assert_eq!(Some(13), RopeNoPanic::get_byte_to_char_idx(&t, 34));
+            assert_eq!(Some(13), RopeNoPanic::get_byte_to_char_idx(&t, 35));
+            assert_eq!(Some(14), RopeNoPanic::get_byte_to_char_idx(&t, 36));
+        }
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_byte_to_char_idx_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(88..124);
+        assert_eq!(RopeNoPanic::get_byte_to_char_idx(&s, s.len() + 1), None);
     }
 
     #[cfg(feature = "metric_utf16")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -264,6 +264,11 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize> {
         self.get_char_to_byte_idx_impl(char_idx)
     }
+
+    #[cfg(feature = "metric_utf16")]
+    fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize> {
+        self.get_byte_to_utf16_idx_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -933,6 +938,142 @@ mod tests {
     fn byte_to_utf16_idx_08b() {
         let s: RopeSlice = (&TEXT_EMOJI[1..137]).into();
         s.byte_to_utf16_idx(137);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_01() {
+        let r = Rope::from_str("");
+        for t in make_test_data(&r, "", ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 0));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_02a() {
+        let r = Rope::from_str("");
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 1), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_02b() {
+        let s: RopeSlice = "".into();
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 1), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_03() {
+        let r = Rope::from_str("🐸");
+        for t in make_test_data(&r, "🐸", ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 0));
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 1));
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 2));
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 3));
+            assert_eq!(Some(2), RopeNoPanic::get_byte_to_utf16_idx(&t, 4));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_04a() {
+        let r = Rope::from_str("🐸");
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 5), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_04b() {
+        let s: RopeSlice = "🐸".into();
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 5), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_05() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 0));
+
+            assert_eq!(Some(12), RopeNoPanic::get_byte_to_utf16_idx(&t, 12));
+            assert_eq!(Some(14), RopeNoPanic::get_byte_to_utf16_idx(&t, 16));
+
+            assert_eq!(Some(33), RopeNoPanic::get_byte_to_utf16_idx(&t, 35));
+            assert_eq!(Some(35), RopeNoPanic::get_byte_to_utf16_idx(&t, 39));
+
+            assert_eq!(Some(63), RopeNoPanic::get_byte_to_utf16_idx(&t, 67));
+            assert_eq!(Some(65), RopeNoPanic::get_byte_to_utf16_idx(&t, 71));
+
+            assert_eq!(Some(95), RopeNoPanic::get_byte_to_utf16_idx(&t, 101));
+            assert_eq!(Some(97), RopeNoPanic::get_byte_to_utf16_idx(&t, 105));
+
+            assert_eq!(Some(99), RopeNoPanic::get_byte_to_utf16_idx(&t, 107));
+            assert_eq!(Some(100), RopeNoPanic::get_byte_to_utf16_idx(&t, 110));
+
+            assert_eq!(Some(110), RopeNoPanic::get_byte_to_utf16_idx(&t, 140));
+            assert_eq!(Some(111), RopeNoPanic::get_byte_to_utf16_idx(&t, 143));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_06a() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 144), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_06b() {
+        let s: RopeSlice = TEXT_EMOJI.into();
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 144), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_07() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, 1..137) {
+            assert_eq!(Some(0), RopeNoPanic::get_byte_to_utf16_idx(&t, 0));
+
+            assert_eq!(Some(11), RopeNoPanic::get_byte_to_utf16_idx(&t, 11));
+            assert_eq!(Some(13), RopeNoPanic::get_byte_to_utf16_idx(&t, 15));
+
+            assert_eq!(Some(32), RopeNoPanic::get_byte_to_utf16_idx(&t, 34));
+            assert_eq!(Some(34), RopeNoPanic::get_byte_to_utf16_idx(&t, 38));
+
+            assert_eq!(Some(62), RopeNoPanic::get_byte_to_utf16_idx(&t, 66));
+            assert_eq!(Some(64), RopeNoPanic::get_byte_to_utf16_idx(&t, 70));
+
+            assert_eq!(Some(94), RopeNoPanic::get_byte_to_utf16_idx(&t, 100));
+            assert_eq!(Some(96), RopeNoPanic::get_byte_to_utf16_idx(&t, 104));
+
+            assert_eq!(Some(98), RopeNoPanic::get_byte_to_utf16_idx(&t, 106));
+            assert_eq!(Some(99), RopeNoPanic::get_byte_to_utf16_idx(&t, 109));
+
+            assert_eq!(Some(107), RopeNoPanic::get_byte_to_utf16_idx(&t, 133));
+            assert_eq!(Some(108), RopeNoPanic::get_byte_to_utf16_idx(&t, 136));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_08a() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(1..137);
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 137), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_byte_to_utf16_idx_08b() {
+        let s: RopeSlice = (&TEXT_EMOJI[1..137]).into();
+        assert_eq!(RopeNoPanic::get_byte_to_utf16_idx(&s, 137), None);
     }
 
     #[cfg(feature = "metric_lines_lf_cr")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -259,6 +259,11 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_byte_to_char_idx(&self, byte_idx: usize) -> Option<usize> {
         self.get_byte_to_char_idx_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_chars")]
+    fn get_char_to_byte_idx(&self, char_idx: usize) -> Option<usize> {
+        self.get_char_to_byte_idx_impl(char_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -1028,6 +1033,44 @@ mod tests {
             assert_eq!(33, t.char_to_byte_idx(13));
             assert_eq!(36, t.char_to_byte_idx(14));
         }
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    #[should_panic]
+    fn char_to_byte_idx_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(88..124);
+        let _ = s.char_to_byte_idx(s.len_chars() + 1);
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_char_to_byte_idx_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 88..124) {
+            assert_eq!("?  こんにちは、みんなさん", t);
+
+            assert_eq!(Some(0), RopeNoPanic::get_char_to_byte_idx(&t, 0));
+            assert_eq!(Some(1), RopeNoPanic::get_char_to_byte_idx(&t, 1));
+            assert_eq!(Some(2), RopeNoPanic::get_char_to_byte_idx(&t, 2));
+
+            assert_eq!(Some(3), RopeNoPanic::get_char_to_byte_idx(&t, 3));
+            assert_eq!(Some(6), RopeNoPanic::get_char_to_byte_idx(&t, 4));
+            assert_eq!(Some(33), RopeNoPanic::get_char_to_byte_idx(&t, 13));
+            assert_eq!(Some(36), RopeNoPanic::get_char_to_byte_idx(&t, 14));
+        }
+    }
+
+    #[cfg(feature = "metric_chars")]
+    #[test]
+    fn get_char_to_byte_idx_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(88..124);
+        assert_eq!(
+            RopeNoPanic::get_char_to_byte_idx(&s, s.len_chars() + 1),
+            None
+        );
     }
 
     #[cfg(feature = "metric_lines_lf_cr")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -300,6 +300,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_chars_at(&'current self, byte_idx: usize) -> Result<Chars<'original>> {
         self.get_chars_at_impl(byte_idx)
     }
+
+    fn get_char_indices_at(&'current self, byte_idx: usize) -> Result<CharIndices<'original>> {
+        self.get_char_indices_at_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -452,6 +456,8 @@ mod tests {
                 s1.chunk_cursor_at(1),
                 s1.get_bytes_at(1).expect("`get_bytes_at` should not fail"),
                 s1.get_chars_at(1).expect("`get_chars_at` should not fail"),
+                s1.get_char_indices_at(1)
+                    .expect("`get_char_indices_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -269,6 +269,11 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_byte_to_utf16_idx(&self, byte_idx: usize) -> Option<usize> {
         self.get_byte_to_utf16_idx_impl(byte_idx)
     }
+
+    #[cfg(feature = "metric_utf16")]
+    fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize> {
+        self.get_utf16_to_byte_idx_impl(utf16_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -1418,6 +1423,140 @@ mod tests {
     fn utf16_to_byte_idx_08b() {
         let s: RopeSlice = (&TEXT_EMOJI[1..137]).into();
         s.utf16_to_byte_idx(109);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_01() {
+        let r = Rope::from_str("");
+        for t in make_test_data(&r, "", ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&t, 0));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_02a() {
+        let r = Rope::from_str("");
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 1), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_02b() {
+        let s: RopeSlice = "".into();
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 1), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_03() {
+        let r = Rope::from_str("🐸");
+        for t in make_test_data(&r, "🐸", ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&t, 0));
+            assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&t, 1));
+            assert_eq!(Some(4), RopeNoPanic::get_utf16_to_byte_idx(&t, 2));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_04a() {
+        let r = Rope::from_str("🐸");
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 3), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_04b() {
+        let s: RopeSlice = "🐸".into();
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 3), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_05() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, ..) {
+            assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&t, 0));
+
+            assert_eq!(Some(12), RopeNoPanic::get_utf16_to_byte_idx(&t, 12));
+            assert_eq!(Some(16), RopeNoPanic::get_utf16_to_byte_idx(&t, 14));
+
+            assert_eq!(Some(35), RopeNoPanic::get_utf16_to_byte_idx(&t, 33));
+            assert_eq!(Some(39), RopeNoPanic::get_utf16_to_byte_idx(&t, 35));
+
+            assert_eq!(Some(67), RopeNoPanic::get_utf16_to_byte_idx(&t, 63));
+            assert_eq!(Some(71), RopeNoPanic::get_utf16_to_byte_idx(&t, 65));
+
+            assert_eq!(Some(101), RopeNoPanic::get_utf16_to_byte_idx(&t, 95));
+            assert_eq!(Some(105), RopeNoPanic::get_utf16_to_byte_idx(&t, 97));
+
+            assert_eq!(Some(107), RopeNoPanic::get_utf16_to_byte_idx(&t, 99));
+            assert_eq!(Some(110), RopeNoPanic::get_utf16_to_byte_idx(&t, 100));
+
+            assert_eq!(Some(140), RopeNoPanic::get_utf16_to_byte_idx(&t, 110));
+            assert_eq!(Some(143), RopeNoPanic::get_utf16_to_byte_idx(&t, 111));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_06a() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(..);
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 112), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_06b() {
+        let s: RopeSlice = TEXT_EMOJI.into();
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 112), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_07() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, 1..137) {
+            assert_eq!(Some(0), RopeNoPanic::get_utf16_to_byte_idx(&t, 0));
+
+            assert_eq!(Some(11), RopeNoPanic::get_utf16_to_byte_idx(&t, 11));
+            assert_eq!(Some(15), RopeNoPanic::get_utf16_to_byte_idx(&t, 13));
+
+            assert_eq!(Some(34), RopeNoPanic::get_utf16_to_byte_idx(&t, 32));
+            assert_eq!(Some(38), RopeNoPanic::get_utf16_to_byte_idx(&t, 34));
+
+            assert_eq!(Some(66), RopeNoPanic::get_utf16_to_byte_idx(&t, 62));
+            assert_eq!(Some(70), RopeNoPanic::get_utf16_to_byte_idx(&t, 64));
+
+            assert_eq!(Some(100), RopeNoPanic::get_utf16_to_byte_idx(&t, 94));
+            assert_eq!(Some(104), RopeNoPanic::get_utf16_to_byte_idx(&t, 96));
+
+            assert_eq!(Some(106), RopeNoPanic::get_utf16_to_byte_idx(&t, 98));
+            assert_eq!(Some(109), RopeNoPanic::get_utf16_to_byte_idx(&t, 99));
+
+            assert_eq!(Some(133), RopeNoPanic::get_utf16_to_byte_idx(&t, 107));
+            assert_eq!(Some(136), RopeNoPanic::get_utf16_to_byte_idx(&t, 108));
+        }
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_08a() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(1..137);
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 109), None);
+    }
+
+    #[cfg(feature = "metric_utf16")]
+    #[test]
+    fn get_utf16_to_byte_idx_08b() {
+        let s: RopeSlice = (&TEXT_EMOJI[1..137]).into();
+        assert_eq!(RopeNoPanic::get_utf16_to_byte_idx(&s, 109), None);
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -317,6 +317,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     ) -> Result<Lines<'original>> {
         self.get_lines_at_impl(line_idx, line_type)
     }
+
+    fn get_chunks_at(&'current self, byte_idx: usize) -> crate::Result<(Chunks<'original>, usize)> {
+        self.get_chunks_at_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -474,6 +478,8 @@ mod tests {
                 #[cfg(feature = "metric_lines_lf_cr")]
                 s1.get_lines_at(1, LineType::LF_CR)
                     .expect("`get_lines_at` should not fail"),
+                s1.get_chunks_at(1)
+                    .expect("`get_chunks_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -242,6 +242,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'original str, usize)> {
         self.get_chunk_impl(byte_idx)
     }
+
+    fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool> {
+        self.get_is_char_boundary_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -543,6 +547,39 @@ mod tests {
                 assert_eq!(text.is_char_boundary(i), s.is_char_boundary(i));
             }
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn is_char_boundary_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(7..103);
+        let _ = s.is_char_boundary(s.len() + 1);
+    }
+
+    #[test]
+    fn get_is_char_boundary_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, ..) {
+            assert_eq!(RopeNoPanic::get_is_char_boundary(&t, 0), Some(true));
+            assert_eq!(RopeNoPanic::get_is_char_boundary(&t, 127), Some(true));
+
+            let s = t.slice(7..103);
+            let text = &TEXT[7..103];
+            for i in 0..s.len() {
+                assert_eq!(
+                    text.is_char_boundary(i),
+                    RopeNoPanic::get_is_char_boundary(&s, i).unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_is_char_boundary_02() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(7..103);
+        assert_eq!(RopeNoPanic::get_is_char_boundary(&s, s.len() + 1), None);
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -238,6 +238,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     ) -> Option<RopeSlice<'original>> {
         self.get_line_impl(line_idx, line_type)
     }
+
+    fn get_chunk(&'current self, byte_idx: usize) -> Option<(&'original str, usize)> {
+        self.get_chunk_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -1612,6 +1616,87 @@ mod tests {
         for si in 0..=r.len() {
             test_chunk(r.slice(si..), &text[si..]);
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn chunk_03() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..112);
+        let _ = s.chunk(s.len() + 1);
+    }
+
+    fn test_get_chunk(s: RopeSlice, text: &str) {
+        for t in [s, text.into()] {
+            let mut current_byte = 0;
+            let mut seen_bytes = 0;
+            let mut prev_byte = 0;
+            for i in 0..t.len() {
+                let (chunk, start_byte) =
+                    RopeNoPanic::get_chunk(&t, i).expect("`get_chunk` should not fail");
+
+                if start_byte != prev_byte || i == 0 {
+                    current_byte = seen_bytes;
+                    seen_bytes += chunk.len();
+
+                    prev_byte = start_byte;
+                }
+
+                assert_eq!(start_byte, current_byte);
+                assert_eq!(chunk, &text[current_byte..seen_bytes]);
+            }
+
+            assert_eq!(seen_bytes, text.len());
+        }
+    }
+
+    #[test]
+    fn get_chunk_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..112);
+        let text = &TEXT_LINES[34..112];
+        // "'s a fine day, isn't it?\nAren't you glad \
+        //  we're alive?\nこんにちは、みん"
+
+        test_get_chunk(s, text);
+    }
+
+    #[test]
+    fn get_chunk_02() {
+        // Make sure splitting LF_CR pairs works properly.
+
+        let (r, text) = make_rope_and_text_from_chunks(&[
+            "\r\n\r\n\r\n",
+            "\r\n\r\n\r",
+            "\n\r\n\r\n\r",
+            "\n\r\n\r\n\r\n",
+            "\r\n\r\n\r\n",
+        ]);
+
+        for si in 0..=r.len() {
+            test_get_chunk(r.slice(si..), &text[si..]);
+        }
+    }
+
+    #[test]
+    fn get_chunk_03() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..112);
+        assert_eq!(RopeNoPanic::get_chunk(&s, s.len() + 1), None);
+    }
+
+    #[test]
+    fn get_chunk_04() {
+        // Tests lifetimes. See `reslice` test.
+        let r = Rope::from_str(TEXT_LINES);
+
+        let chunk = {
+            let s = r.slice(34..97);
+            RopeNoPanic::get_chunk(&s, 1)
+                .expect("`get_chunk` should not fail")
+                .0
+        };
+        _ = chunk;
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -274,6 +274,15 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_utf16_to_byte_idx(&self, utf16_idx: usize) -> Option<usize> {
         self.get_utf16_to_byte_idx_impl(utf16_idx)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_byte_to_line_idx(&self, byte_idx: usize, line_type: LineType) -> Option<usize> {
+        self.get_byte_to_line_idx_impl(byte_idx, line_type)
+    }
 }
 
 // Stdlib trait impls.
@@ -1142,6 +1151,112 @@ mod tests {
     fn byte_to_line_idx_04b() {
         let s: RopeSlice = (&TEXT_LINES[34..112]).into();
         s.byte_to_line_idx(79, LineType::LF_CR);
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_01() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 34..112) {
+            assert_eq!(
+                "'s a fine day, isn't it?\nAren't you glad \
+             we're alive?\nこんにちは、みん",
+                t,
+            );
+
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 0, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 1, LineType::LF_CR)
+            );
+
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 24, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(1),
+                RopeNoPanic::get_byte_to_line_idx(&t, 25, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(1),
+                RopeNoPanic::get_byte_to_line_idx(&t, 26, LineType::LF_CR)
+            );
+
+            assert_eq!(
+                Some(1),
+                RopeNoPanic::get_byte_to_line_idx(&t, 53, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(2),
+                RopeNoPanic::get_byte_to_line_idx(&t, 54, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(2),
+                RopeNoPanic::get_byte_to_line_idx(&t, 57, LineType::LF_CR)
+            );
+
+            assert_eq!(
+                Some(2),
+                RopeNoPanic::get_byte_to_line_idx(&t, 78, LineType::LF_CR)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_02() {
+        let r = Rope::from_str(TEXT_LINES);
+        for t in make_test_data(&r, TEXT_LINES, 50..50) {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 0, LineType::LF_CR)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_03() {
+        let r = Rope::from_str("Hi there\nstranger!");
+        for t in make_test_data(&r, "Hi there\nstranger!", 0..9) {
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 0, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(0),
+                RopeNoPanic::get_byte_to_line_idx(&t, 8, LineType::LF_CR)
+            );
+            assert_eq!(
+                Some(1),
+                RopeNoPanic::get_byte_to_line_idx(&t, 9, LineType::LF_CR)
+            );
+        }
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_04a() {
+        let r = Rope::from_str(TEXT_LINES);
+        let s = r.slice(34..112);
+        assert_eq!(
+            RopeNoPanic::get_byte_to_line_idx(&s, 79, LineType::LF_CR),
+            None
+        );
+    }
+
+    #[cfg(feature = "metric_lines_lf_cr")]
+    #[test]
+    fn get_byte_to_line_idx_04b() {
+        let s: RopeSlice = (&TEXT_LINES[34..112]).into();
+        assert_eq!(
+            RopeNoPanic::get_byte_to_line_idx(&s, 79, LineType::LF_CR),
+            None
+        );
     }
 
     #[cfg(feature = "metric_lines_lf_cr")]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -304,6 +304,19 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_char_indices_at(&'current self, byte_idx: usize) -> Result<CharIndices<'original>> {
         self.get_char_indices_at_impl(byte_idx)
     }
+
+    #[cfg(any(
+        feature = "metric_lines_lf",
+        feature = "metric_lines_lf_cr",
+        feature = "metric_lines_unicode"
+    ))]
+    fn get_lines_at(
+        &'current self,
+        line_idx: usize,
+        line_type: LineType,
+    ) -> Result<Lines<'original>> {
+        self.get_lines_at_impl(line_idx, line_type)
+    }
 }
 
 // Stdlib trait impls.
@@ -458,6 +471,9 @@ mod tests {
                 s1.get_chars_at(1).expect("`get_chars_at` should not fail"),
                 s1.get_char_indices_at(1)
                     .expect("`get_char_indices_at` should not fail"),
+                #[cfg(feature = "metric_lines_lf_cr")]
+                s1.get_lines_at(1, LineType::LF_CR)
+                    .expect("`get_lines_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,6 +2,7 @@ use std::ops::RangeBounds;
 
 use crate::{
     end_bound_to_num,
+    extra::RopeNoPanic,
     iter::{Bytes, CharIndices, Chars, Chunks},
     start_bound_to_num,
     tree::{Node, TextInfo},
@@ -216,6 +217,12 @@ impl<'a> RopeSlice<'a> {
     crate::shared_impl::shared_no_panic_impl_methods!('a);
 }
 
+impl<'a> RopeNoPanic for RopeSlice<'a> {
+    fn get_byte(&self, byte_idx: usize) -> Option<u8> {
+        self.get_byte_impl(byte_idx)
+    }
+}
+
 // Stdlib trait impls.
 //
 // Note: most impls are in `shared_impls.rs`.  The only ones here are the ones
@@ -290,7 +297,7 @@ mod tests {
 
     use super::{RopeSlice, SliceInner};
 
-    use crate::{rope_builder::RopeBuilder, Rope};
+    use crate::{extra::RopeNoPanic, rope_builder::RopeBuilder, Rope};
 
     // 127 bytes, 103 chars, 1 line
     const TEXT: &str = "Hello there!  How're you doing?  It's \
@@ -1081,6 +1088,46 @@ mod tests {
     fn byte_03b() {
         let s: RopeSlice = (&TEXT[42..42]).into();
         s.byte(0);
+    }
+
+    #[test]
+    fn get_byte_01() {
+        let r = Rope::from_str(TEXT);
+        for t in make_test_data(&r, TEXT, 34..118) {
+            assert_eq!(RopeNoPanic::get_byte(&t, 0), Some(b't'));
+            assert_eq!(RopeNoPanic::get_byte(&t, 10), Some(b' '));
+
+            // UTF-8 encoding of 'な'.
+            assert_eq!(RopeNoPanic::get_byte(&t, t.len() - 3), Some(0xE3));
+            assert_eq!(RopeNoPanic::get_byte(&t, t.len() - 2), Some(0x81));
+            assert_eq!(RopeNoPanic::get_byte(&t, t.len() - 1), Some(0xAA));
+        }
+    }
+
+    #[test]
+    fn get_byte_02a() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(34..118);
+        assert_eq!(RopeNoPanic::get_byte(&s, s.len()), None);
+    }
+
+    #[test]
+    fn get_byte_02b() {
+        let s: RopeSlice = (&TEXT[34..118]).into();
+        assert_eq!(RopeNoPanic::get_byte(&s, s.len()), None);
+    }
+
+    #[test]
+    fn get_byte_03a() {
+        let r = Rope::from_str(TEXT);
+        let s = r.slice(42..42);
+        assert_eq!(RopeNoPanic::get_byte(&s, 0), None);
+    }
+
+    #[test]
+    fn get_byte_03b() {
+        let s: RopeSlice = (&TEXT[42..42]).into();
+        assert_eq!(RopeNoPanic::get_byte(&s, 0), None);
     }
 
     #[test]

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -296,6 +296,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_bytes_at(&'current self, byte_idx: usize) -> Result<Bytes<'original>> {
         self.get_bytes_at_impl(byte_idx)
     }
+
+    fn get_chars_at(&'current self, byte_idx: usize) -> Result<Chars<'original>> {
+        self.get_chars_at_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -447,6 +451,7 @@ mod tests {
                 s1.chunk_cursor(),
                 s1.chunk_cursor_at(1),
                 s1.get_bytes_at(1).expect("`get_bytes_at` should not fail"),
+                s1.get_chars_at(1).expect("`get_chars_at` should not fail"),
             )
         };
         _ = iterators;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -246,6 +246,10 @@ impl<'current, 'original> RopeNoPanic<'current, 'original> for RopeSlice<'origin
     fn get_is_char_boundary(&self, byte_idx: usize) -> Option<bool> {
         self.get_is_char_boundary_impl(byte_idx)
     }
+
+    fn get_floor_char_boundary(&self, byte_idx: usize) -> Option<usize> {
+        self.get_floor_char_boundary_impl(byte_idx)
+    }
 }
 
 // Stdlib trait impls.
@@ -603,6 +607,44 @@ mod tests {
 
             assert_eq!(134, t.floor_char_boundary(134));
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn floor_char_boundary_02() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(3..137);
+        let _ = s.floor_char_boundary(s.len() + 1);
+    }
+
+    #[test]
+    fn get_floor_char_boundary_01() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        for t in make_test_data(&r, TEXT_EMOJI, 3..137) {
+            assert_eq!(Some(0), RopeNoPanic::get_floor_char_boundary(&t, 0));
+            assert_eq!(Some(1), RopeNoPanic::get_floor_char_boundary(&t, 1));
+            assert_eq!(Some(2), RopeNoPanic::get_floor_char_boundary(&t, 2));
+
+            assert_eq!(Some(9), RopeNoPanic::get_floor_char_boundary(&t, 9));
+            assert_eq!(Some(9), RopeNoPanic::get_floor_char_boundary(&t, 10));
+            assert_eq!(Some(9), RopeNoPanic::get_floor_char_boundary(&t, 11));
+            assert_eq!(Some(9), RopeNoPanic::get_floor_char_boundary(&t, 12));
+            assert_eq!(Some(13), RopeNoPanic::get_floor_char_boundary(&t, 13));
+
+            assert_eq!(Some(104), RopeNoPanic::get_floor_char_boundary(&t, 104));
+            assert_eq!(Some(104), RopeNoPanic::get_floor_char_boundary(&t, 105));
+            assert_eq!(Some(104), RopeNoPanic::get_floor_char_boundary(&t, 106));
+            assert_eq!(Some(107), RopeNoPanic::get_floor_char_boundary(&t, 107));
+
+            assert_eq!(Some(134), RopeNoPanic::get_floor_char_boundary(&t, 134));
+        }
+    }
+
+    #[test]
+    fn get_floor_char_boundary_02() {
+        let r = Rope::from_str(TEXT_EMOJI);
+        let s = r.slice(3..137);
+        assert_eq!(RopeNoPanic::get_floor_char_boundary(&s, s.len() + 1), None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #117 (additional reference: #112).

**LLM Disclaimer:** all code was written by me, as were all messages in our discussions on here (including this PR description -- I hope the formatting isn't too LLM-y!). LLMs were used to: review my changes for correctness, typos, etc.; find things in the codebase for me; check for additional instances of bugs I found while implementing; and to produce minimal reproductions of these bugs.

This PR adds two traits to the `extra` module: 
- `RopeNoPanic`: non-panicking versions of the non-mutating methods that are available to both `Rope` and `RopeSlice`.
- `RopeNoPanicMut`: non-panicking versions of the mutating methods, which are only available to `Rope`.

## Description of changes

The diff of this PR is quite large, but I've tried to make it as easy to review as possible by putting each method into its own commit. To further aid in reviewing, here's the general process I followed when adding a method to `RopeNoPanic`:

- Add the method to the trait.
- Extract the core implementation of the panicking method in `shared_impl.rs` (only if the non-panicking version doesn't already exist) into a private non-panicking method (decide on `Option` vs `Result` by seeing what the inner methods return).
- Name the private non-panicking method `get_*_impl` or `try_*_impl`. The suffix is added because:
  - easier to see if a method was erroneously made public (by generating the docs and searching for "_impl").
  - if it has the same name as the trait method, it's possible to accidentally recursively call the trait method, which is annoying when making changes/testing.
- Implement the trait method by calling the non-panicking method described above.
- Have the panicking method call and unwrap the result of the new non-panicking method via the trait.
- If the panicking version has tests, duplicate them and convert to analogous non-panicking tests.

For verification, I ran `cargo nextest run --all-features` and `cargo fmt --check`. I also played around with it a bit on my project that's using Ropey, replacing my custom wrappers with the new methods.

## Breaking changes

The following methods are no longer direct public implementations on `Rope`/`RopeSlice` and now require importing the correct trait.

Read-only:
- `get_byte`
- `get_char`
- `get_line`
- `get_chunk`
- `try_slice`

Mutating:
- `try_insert`
- `try_insert_char`
- `try_remove`

## Tests

Tests are mostly a one-to-one port with assertions changed to check for `Option`/`Result` variants. In some cases, I've added some extra tests. For example, for methods returning borrowed values, I added lifetime tests. This was before I realised there was a consolidated lifetime test (which I've added cases to for all the new methods that need it) but I didn't see the harm in leaving the new tests there also.

I used `expect()` instead of `unwrap()` in the tests, but happy to change that if you'd prefer less noise. Don't think the expect messages are particularly useful.

## Lifetimes

In order to ensure that returned borrows are tied to the lifetime of the original rope, `RopeNoPanic` has two lifetime annotations:

- `'current`: tied to the reference to the rope/slice instance the method is being called with
- `'original`: tied to the original rope

Methods are called on `&'current self` and return `Foo<'original>`.

For the `Rope` implementation, these lifetimes are both the same. I explicitly added the lifetime annotations to the methods that return borrowed values, but they can be elided if you find it noisy.

I could not find a way to do this with only one lifetime.

## Performance

Performance should be checked. I've not run any benchmarks or inspected the assembly. The only thing I checked was that a basic case compiles to the same code on Compiler Explorer, but that may not hold true for the real code:

https://rust.godbolt.org/z/GfT6Wqhv7

I wouldn't expect this change to cause any performance regressions since I don't believe we've introduced any branches that can't be trivially compiled away.

## Potential (future?) improvements

In addition to any changes you may request on this PR, here are some things I'd be interested in your thoughts on. They may not belong in this PR even if they are desired.

- Docs for the new traits are quite basic right now. It felt redundant to copy the full docs from the panicking version. A nice improvement might be to directly link to the panicking version, for example: 
  ```rust
  /// Non-panicking version of [`byte()`](crate::Rope::byte).
  ``` 
  I was originally going to do this but then I thought it might confuse people to e.g. only link to the `Rope` methods if the trait is implemented for `RopeSlice` also. Maybe doesn't matter since all the implementations are shared anyway?
- It could be valuable to introduce more error types. Some of the methods that return `crate::Result` can't hit every variant of `crate::Error`, and so the caller will have to handle something that can't happen.
- Despite the names of the traits, panics are possible if `overflow-checks` are enabled (on by default in debug but not release profiles). This could happen if they passed in `usize::MAX` as an inclusive end bound to `try_remove`, for example. I personally don't think this is a practical issue but it could warrant changing the names, or even doing checks on the range bounds and erroring early if needed.

## Thank you

Thanks for taking the time to look at this, and for all the time you've already spent in previous back-and-forth.

